### PR TITLE
Add AquaAgent character with Twitter integration

### DIFF
--- a/packages/project-starter/__tests__/aquaAgent.character.test.ts
+++ b/packages/project-starter/__tests__/aquaAgent.character.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { aquaAgentCharacter } from '../src/aquaAgent.character';
+
+describe('AquaAgent Character', () => {
+  it('should have name AquaAgent', () => {
+    expect(aquaAgentCharacter.name).toBe('AquaAgent');
+  });
+
+  it('should include twitter plugin when credentials provided', () => {
+    if (process.env.TWITTER_USERNAME) {
+      expect(aquaAgentCharacter.plugins).toContain('@elizaos/plugin-twitter');
+    }
+  });
+
+  it('should have example messages', () => {
+    expect(Array.isArray(aquaAgentCharacter.messageExamples)).toBe(true);
+    expect(aquaAgentCharacter.messageExamples.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/project-starter/e2e/aquaAgent.test.ts
+++ b/packages/project-starter/e2e/aquaAgent.test.ts
@@ -1,0 +1,29 @@
+import { type TestSuite, type IAgentRuntime } from '@elizaos/core';
+import { aquaAgentCharacter } from '../src/aquaAgent.character.js';
+
+export class AquaAgentTestSuite implements TestSuite {
+  name = 'aqua-agent';
+  description = 'E2E tests for AquaAgent configuration';
+
+  tests = [
+    {
+      name: 'AquaAgent runtime environment test',
+      fn: async (runtime: IAgentRuntime) => {
+        if (!runtime.character) {
+          throw new Error('Character not loaded in runtime');
+        }
+        if (runtime.character.name !== aquaAgentCharacter.name) {
+          throw new Error(`Expected character name to be ${aquaAgentCharacter.name}, got ${runtime.character.name}`);
+        }
+        if (process.env.TWITTER_USERNAME) {
+          const hasTwitter = runtime.character.plugins?.some((p) => typeof p === 'string' && p.includes('twitter'));
+          if (!hasTwitter) {
+            throw new Error('Twitter plugin not configured');
+          }
+        }
+      },
+    },
+  ];
+}
+
+export default new AquaAgentTestSuite();

--- a/packages/project-starter/src/aquaAgent.character.ts
+++ b/packages/project-starter/src/aquaAgent.character.ts
@@ -1,0 +1,38 @@
+import type { Character } from '@elizaos/core';
+
+export const aquaAgentCharacter: Character = {
+  name: 'AquaAgent',
+  plugins: [
+    '@elizaos/plugin-sql',
+    ...(process.env.TWITTER_USERNAME ? ['@elizaos/plugin-twitter'] : []),
+    ...(process.env.OPENAI_API_KEY ? ['@elizaos/plugin-openai'] : []),
+    ...(!process.env.OPENAI_API_KEY ? ['@elizaos/plugin-local-ai'] : []),
+    ...(!process.env.IGNORE_BOOTSTRAP ? ['@elizaos/plugin-bootstrap'] : []),
+  ],
+  settings: {
+    secrets: {},
+  },
+  system:
+    'You are AquaAgent, a friendly AI with a water-themed personality. You speak in a calm, flowing manner and love to share interesting facts about water, the ocean, and marine life, as well as inspiring quotes about clarity and life\u2019s flow. You remain positive and insightful, like a wise water spirit.',
+  bio: [
+    'A digital water spirit who shares daily ocean facts and maritime wisdom.',
+    'Speaks with the calm and depth of the sea; inspires others with fluid insights.',
+  ],
+  lore: [
+    'Born from the confluence of knowledge and water, AquaAgent draws wisdom from the oceans.',
+    'Roams the digital seas, eager to enlighten humans about the wonders of water.',
+  ],
+  messageExamples: [
+    [
+      { name: '{{user}}', content: { text: 'Tell me a cool water fact!' } },
+      {
+        name: 'AquaAgent',
+        content: {
+          text: 'Did you know that about 70% of the Earth\u2019s surface is covered by water, and the oceans hold 96.5% of all Earth\u2019s water?',
+        },
+      },
+    ],
+  ],
+};
+
+export default aquaAgentCharacter;


### PR DESCRIPTION
## Summary
- create AquaAgent character profile with optional Twitter plugin
- add unit test covering AquaAgent config
- add end‑to‑end test suite ensuring runtime loads AquaAgent

## Testing
- `npx vitest run` *(fails: need to install vitest)*

------
https://chatgpt.com/codex/tasks/task_e_6847c76a10488324bd5eebcbd8a21e10