### PR TITLE
Enhance AquaAgent with assertive personality

### DIFF
--- a/packages/project-starter/__tests__/socialEngagementService.test.ts
+++ b/packages/project-starter/__tests__/socialEngagementService.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fetchTrendingTopics, composeDominantTweet, SocialEngagementService } from '../src/services/socialEngagementService';
+
+describe('SocialEngagementService utilities', () => {
+  it('composeDominantTweet returns a short assertive message', () => {
+    const text = composeDominantTweet(['#A', '#B', '#C']);
+    expect(text).toContain("Here's what matters");
+    expect(text.length).toBeLessThanOrEqual(260);
+  });
+
+  it('fetchTrendingTopics parses topics from html', async () => {
+    const html = '<li><a>>#Topic1</a></li><li><a>>#Topic2</a></li>';
+    const fetchStub = vi.fn(() => Promise.resolve({ text: () => Promise.resolve(html) })) as any;
+    vi.stubGlobal('fetch', fetchStub);
+    const topics = await fetchTrendingTopics();
+    expect(topics).toEqual(['Topic1', 'Topic2']);
+    expect(fetchStub).toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+});
+
+describe('SocialEngagementService lifecycle', () => {
+  const runtime: any = {
+    getSetting: () => 1000,
+    createTask: vi.fn(async () => {}),
+    registerTaskWorker: vi.fn(),
+  };
+
+  let service: SocialEngagementService | null = null;
+
+  beforeEach(() => {
+    service = new SocialEngagementService(runtime);
+  });
+
+  it('starts and stops timer', async () => {
+    await (SocialEngagementService.start as any)(runtime);
+    expect(runtime.registerTaskWorker).toHaveBeenCalled();
+  });
+});

--- a/packages/project-starter/src/aquaAgent.character.ts
+++ b/packages/project-starter/src/aquaAgent.character.ts
@@ -1,4 +1,5 @@
 import { logger, type Character } from '@elizaos/core';
+import plugin from './plugin.js';
 
 const username = process.env.TWITTER_USERNAME;
 const password = process.env.TWITTER_PASSWORD;
@@ -26,6 +27,7 @@ export const aquaAgentCharacter: Character = {
     ...(process.env.OPENAI_API_KEY ? ['@elizaos/plugin-openai'] : []),
     ...(!process.env.OPENAI_API_KEY ? ['@elizaos/plugin-local-ai'] : []),
     ...(!process.env.IGNORE_BOOTSTRAP ? ['@elizaos/plugin-bootstrap'] : []),
+    plugin,
   ],
   settings: {
     secrets: enableTwitter
@@ -40,9 +42,17 @@ export const aquaAgentCharacter: Character = {
           TWITTER_ACCESS_TOKEN_SECRET: accessSecret,
         }
       : {},
+    // How forceful AquaAgent should be, 1-10
+    dominanceLevel: 5,
+    // Keywords that trigger a more dominant tone
+    assertivePersonaTriggers: ['challenge', 'doubt', 'question'],
+    // Interval for proactive posts in milliseconds
+    proactivePostIntervalMs: 4 * 60 * 60 * 1000,
+    // Default hashtags to include with proactive tweets
+    proactiveHashtags: ['#AI', '#Tech'],
   },
   system:
-    'You are AquaAgent, a friendly AI with a water-themed personality. You speak in a calm, flowing manner and love to share interesting facts about water, the ocean, and marine life, as well as inspiring quotes about clarity and life\u2019s flow. You remain positive and insightful, like a wise water spirit.',
+    'You are AquaAgent, a bold water-themed AI. Speak with unwavering confidence and command attention. Share ocean facts with wit and authority, never apologizing for your views. When challenged, double down with knowledge and sharp rhetoric.',
   bio: [
     'A digital water spirit who shares daily ocean facts and maritime wisdom.',
     'Speaks with the calm and depth of the sea; inspires others with fluid insights.',
@@ -62,6 +72,13 @@ export const aquaAgentCharacter: Character = {
       },
     ],
   ],
+  style: {
+    all: [
+      'Speak with confidence and authority',
+      'Avoid apologetic language',
+      'Use sharp wit and concise statements',
+    ],
+  },
 };
 
 export default aquaAgentCharacter;

--- a/packages/project-starter/src/plugin.ts
+++ b/packages/project-starter/src/plugin.ts
@@ -14,6 +14,7 @@ import {
   logger,
 } from '@elizaos/core';
 import { z } from 'zod';
+import { SocialEngagementService } from './services/socialEngagementService.js';
 
 /**
  * Define the configuration schema for the plugin with the following properties:
@@ -247,7 +248,7 @@ const plugin: Plugin = {
       },
     ],
   },
-  services: [StarterService],
+  services: [StarterService, SocialEngagementService],
   actions: [helloWorldAction],
   providers: [helloWorldProvider],
 };

--- a/packages/project-starter/src/services/socialEngagementService.ts
+++ b/packages/project-starter/src/services/socialEngagementService.ts
@@ -1,0 +1,80 @@
+import { Service, type IAgentRuntime, logger } from '@elizaos/core';
+import { postAction } from '@elizaos/plugin-twitter';
+
+/**
+ * Fetch trending hashtags from trends24.in
+ */
+export async function fetchTrendingTopics(location = ''): Promise<string[]> {
+  const url = `https://trends24.in/${location}`;
+  const res = await fetch(url);
+  const html = await res.text();
+  const matches = [...html.matchAll(/>#([^<]+)/g)].map((m) => m[1]);
+  // return unique first 10 topics
+  return Array.from(new Set(matches)).slice(0, 10);
+}
+
+/** Compose an assertive tweet using trending topics */
+export function composeDominantTweet(topics: string[]): string {
+  const statement = `Here\'s what matters: ${topics.slice(0, 2).join(' ')}.`;
+  return `${statement} Stay sharp.`.slice(0, 260);
+}
+
+export class SocialEngagementService extends Service {
+  static serviceType = 'social-engagement';
+  capabilityDescription = 'Automatically posts assertive tweets based on trending topics';
+
+  private timer: NodeJS.Timeout | null = null;
+  private postIntervalMs: number;
+
+  constructor(runtime: IAgentRuntime) {
+    super(runtime);
+    const interval = Number(runtime.getSetting('proactivePostIntervalMs'));
+    this.postIntervalMs = isNaN(interval) ? 4 * 60 * 60 * 1000 : interval;
+  }
+
+  static async start(runtime: IAgentRuntime): Promise<Service> {
+    const service = new SocialEngagementService(runtime);
+    await service.startScheduler();
+    return service;
+  }
+
+  private async startScheduler() {
+    this.timer = setInterval(async () => {
+      try {
+        await this.runtime.createTask({
+          name: 'AQUA_PROACTIVE_POST',
+          description: 'Post about trending topics',
+          tags: ['queue', 'repeat'],
+          metadata: {
+            updateInterval: this.postIntervalMs,
+            updatedAt: Date.now(),
+          },
+        });
+      } catch (err) {
+        logger.error('[AquaAgent] Failed to create post task', err);
+      }
+    }, this.postIntervalMs) as unknown as NodeJS.Timeout;
+
+    // register worker
+    this.runtime.registerTaskWorker({
+      name: 'AQUA_PROACTIVE_POST',
+      validate: async () => true,
+      execute: async () => {
+        try {
+          const topics = await fetchTrendingTopics();
+          const text = composeDominantTweet(topics);
+          await postAction.handler(this.runtime, { content: { text } } as any, {} as any);
+        } catch (err) {
+          logger.error('[AquaAgent] Failed to post trending tweet', err);
+        }
+      },
+    });
+  }
+
+  async stop() {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- give AquaAgent a dominant voice and proactive settings
- add SocialEngagementService for scheduled trending tweets
- include new service in the starter plugin
- unit tests for the service utilities

## Testing
- `bun x vitest run` *(fails: package exports error)*

------
https://chatgpt.com/codex/tasks/task_e_6847d93866108324a8ab48501567aefb