### PR TITLE
Add AquaAgent launch helper

### DIFF
--- a/packages/project-starter/.env.example
+++ b/packages/project-starter/.env.example
@@ -64,6 +64,7 @@ POSTGRES_URL=
 ### LOGGING CONFIGURATION ###
 # Logging Configuration (supported: fatal, error, warn, info, debug, trace | default: info)
 LOG_LEVEL=
+ELIZA_SERVER_AUTH_TOKEN=
 
 # Sentry Configuration
 SENTRY_LOGGING=true

--- a/packages/project-starter/README.md
+++ b/packages/project-starter/README.md
@@ -135,3 +135,28 @@ confirming the connection:
 
 With the tweet scheduler enabled, AquaAgent periodically posts ocean facts from
 the Goobingston account sample data and automatically replies to mentions.
+
+### Launching AquaAgent
+
+To start AquaAgent without manually registering it in the dashboard, run the provided launch script:
+
+```bash
+bun run src/launchAquaAgent.ts
+```
+
+The script initializes an `AgentServer`, registers AquaAgent, preloads its model and starts the HTTP server. When you see `AquaAgent ready` in the console the agent is fully initialized.
+
+If you prefer using the CLI you can also load the included JSON profile:
+
+```bash
+elizaos start --characters="characters/AquaAgent.json"
+```
+
+### Server Authentication
+
+Set `ELIZA_SERVER_AUTH_TOKEN` in your `.env` to enable API authentication and remove startup warnings.
+
+### Windows Path Warnings
+
+Running outside of WSL may produce `The system cannot find the path specified` messages. Use WSL2 or ensure all data directories exist to avoid them.
+

--- a/packages/project-starter/characters/AquaAgent.json
+++ b/packages/project-starter/characters/AquaAgent.json
@@ -1,0 +1,30 @@
+{
+  "name": "AquaAgent",
+  "plugins": [
+    "@elizaos/plugin-sql",
+    "@elizaos/plugin-local-ai",
+    "@elizaos/plugin-bootstrap"
+  ],
+  "system": "You are AquaAgent, a bold water-themed AI. Speak with unwavering confidence and command attention. Share ocean facts with wit and authority, never apologizing for your views. When challenged, double down with knowledge and sharp rhetoric.",
+  "bio": [
+    "A digital water spirit who shares daily ocean facts and maritime wisdom.",
+    "Speaks with the calm and depth of the sea; inspires others with fluid insights."
+  ],
+  "lore": [
+    "Born from the confluence of knowledge and water, AquaAgent draws wisdom from the oceans.",
+    "Roams the digital seas, eager to enlighten humans about the wonders of water."
+  ],
+  "messageExamples": [
+    [
+      { "name": "{{user}}", "content": { "text": "Tell me a cool water fact!" } },
+      { "name": "AquaAgent", "content": { "text": "Did you know that about 70% of the Earth’s surface is covered by water, and the oceans hold 96.5% of all Earth’s water?" } }
+    ]
+  ],
+  "style": {
+    "all": [
+      "Speak with confidence and authority",
+      "Avoid apologetic language",
+      "Use sharp wit and concise statements"
+    ]
+  }
+}

--- a/packages/project-starter/e2e/launchAquaAgent.test.ts
+++ b/packages/project-starter/e2e/launchAquaAgent.test.ts
@@ -1,0 +1,31 @@
+import { test, expect } from 'bun:test';
+
+// This test runs the launch script and waits for the ready message
+
+test('launch script initializes AquaAgent', async () => {
+  const proc = Bun.spawn({
+    cmd: ['bun', 'run', 'src/launchAquaAgent.ts'],
+    cwd: import.meta.dir + '/..',
+    env: { ...process.env, NODE_ENV: 'test' },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  let ready = false;
+  const startTime = Date.now();
+  const timeoutMs = 20000;
+
+  for await (const chunk of proc.stdout) {
+    const text = chunk.toString();
+    if (text.includes('AquaAgent ready')) {
+      ready = true;
+      break;
+    }
+    if (Date.now() - startTime > timeoutMs) {
+      break;
+    }
+  }
+
+  proc.kill();
+  expect(ready).toBe(true);
+});

--- a/packages/project-starter/src/launchAquaAgent.ts
+++ b/packages/project-starter/src/launchAquaAgent.ts
@@ -1,0 +1,41 @@
+import { AgentRuntime, AgentServer, ModelType, logger } from '@elizaos/core';
+import aquaAgentCharacter, { initAquaAgent } from './aquaAgent.character.js';
+import plugin from './plugin.js';
+
+/**
+ * Start an AgentServer and register AquaAgent.
+ * The model is warmed up once the runtime is initialized.
+ */
+export async function launchAquaAgent() {
+  const server = new AgentServer();
+  await server.initialize();
+
+  const runtime = new AgentRuntime({
+    character: aquaAgentCharacter,
+    plugins: [plugin],
+    settings: process.env as any,
+  });
+
+  await runtime.initialize();
+  await initAquaAgent(runtime);
+  server.registerAgent(runtime);
+
+  try {
+    await runtime.useModel(ModelType.TEXT_SMALL, { prompt: ' ' });
+    logger.info('[AquaAgent] Model preloaded');
+  } catch (error) {
+    logger.warn('[AquaAgent] Model preload failed', error);
+  }
+
+  const port = Number(process.env.SERVER_PORT || 3000);
+  server.start(port);
+  logger.success(`AquaAgent ready on port ${port}`);
+  return { server, runtime };
+}
+
+if (import.meta.main) {
+  launchAquaAgent().catch((err) => {
+    logger.error('Failed to launch AquaAgent', err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- add launch script to preload model and auto-register AquaAgent
- document script usage and auth token setup
- provide AquaAgent JSON for `--characters` flag
- add e2e test verifying the launch script
- update env example with ELIZA_SERVER_AUTH_TOKEN

## Testing
- `bun run test` *(fails: vitest could not resolve @elizaos/core)*

------
https://chatgpt.com/codex/tasks/task_e_684876a8447c8324b4fa7b38e9d38390