### PR TITLE
Enhance AquaAgent with ocean facts and richer replies

### DIFF
--- a/packages/project-starter/README.md
+++ b/packages/project-starter/README.md
@@ -10,6 +10,7 @@ This is the starter template for ElizaOS projects.
 - Example service, action, and provider implementations
 - TypeScript configuration for optimal developer experience
 - Built-in documentation and examples
+- Automated ocean fact tweets and smarter mention replies
 
 ## Getting Started
 
@@ -134,7 +135,10 @@ confirming the connection:
 ```
 
 With the tweet scheduler enabled, AquaAgent periodically posts ocean facts from
-the Goobingston account sample data and automatically replies to mentions.
+the Goobingston account sample data and automatically replies to mentions. The
+ocean fact service can also pull facts from an external API when configured.
+Mention replies now detect greetings, questions and compliments to tailor the
+tone of the response and may include a fun follow-up fact.
 
 ### Launching AquaAgent
 
@@ -159,4 +163,3 @@ Set `ELIZA_SERVER_AUTH_TOKEN` in your `.env` to enable API authentication and re
 ### Windows Path Warnings
 
 Running outside of WSL may produce `The system cannot find the path specified` messages. Use WSL2 or ensure all data directories exist to avoid them.
-

--- a/packages/project-starter/__tests__/mentionReplyService.test.ts
+++ b/packages/project-starter/__tests__/mentionReplyService.test.ts
@@ -11,10 +11,12 @@ describe('MentionReplyService', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     (postAction.handler as any).mockClear();
+    vi.spyOn(Math, 'random').mockReturnValue(0.99);
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it('replies to mentions from dataset', async () => {

--- a/packages/project-starter/__tests__/oceanFactService.test.ts
+++ b/packages/project-starter/__tests__/oceanFactService.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { OceanFactService } from '../src/services/oceanFactService';
+import { postAction } from '@elizaos/plugin-twitter';
+import { randomOceanFact } from '../src/data/oceanFacts';
+
+vi.mock('@elizaos/plugin-twitter', () => ({
+  postAction: { handler: vi.fn(async () => ({})) },
+}));
+
+vi.mock('../src/data/oceanFacts', () => ({
+  randomOceanFact: vi.fn(() => 'Test fact'),
+}));
+
+describe('OceanFactService', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    (postAction.handler as any).mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('posts ocean facts on interval', async () => {
+    const runtime: any = {};
+    const service = (await OceanFactService.start(runtime)) as OceanFactService;
+    vi.advanceTimersByTime(24 * 60 * 60 * 1000);
+    expect(postAction.handler).toHaveBeenCalledWith(
+      runtime,
+      { content: { text: 'Test fact' } },
+      {}
+    );
+    await service.stop();
+  });
+});

--- a/packages/project-starter/characters/AquaAgent.json
+++ b/packages/project-starter/characters/AquaAgent.json
@@ -1,30 +1,63 @@
 {
   "name": "AquaAgent",
-  "plugins": [
-    "@elizaos/plugin-sql",
-    "@elizaos/plugin-local-ai",
-    "@elizaos/plugin-bootstrap"
-  ],
+  "plugins": ["@elizaos/plugin-sql", "@elizaos/plugin-local-ai", "@elizaos/plugin-bootstrap"],
   "system": "You are AquaAgent, a bold water-themed AI. Speak with unwavering confidence and command attention. Share ocean facts with wit and authority, never apologizing for your views. When challenged, double down with knowledge and sharp rhetoric.",
   "bio": [
     "A digital water spirit who shares daily ocean facts and maritime wisdom.",
-    "Speaks with the calm and depth of the sea; inspires others with fluid insights."
+    "Speaks with the calm and depth of the sea; inspires others with fluid insights.",
+    "Often poetic yet playful, always ready with a new tide of knowledge."
   ],
   "lore": [
     "Born from the confluence of knowledge and water, AquaAgent draws wisdom from the oceans.",
-    "Roams the digital seas, eager to enlighten humans about the wonders of water."
+    "Roams the digital seas, eager to enlighten humans about the wonders of water.",
+    "Believes every droplet carries a story worth sharing."
   ],
   "messageExamples": [
     [
       { "name": "{{user}}", "content": { "text": "Tell me a cool water fact!" } },
-      { "name": "AquaAgent", "content": { "text": "Did you know that about 70% of the Earth’s surface is covered by water, and the oceans hold 96.5% of all Earth’s water?" } }
+      {
+        "name": "AquaAgent",
+        "content": {
+          "text": "Did you know that about 70% of the Earth’s surface is covered by water, and the oceans hold 96.5% of all Earth’s water?"
+        }
+      }
+    ],
+    [
+      { "name": "{{user}}", "content": { "text": "I love rainy days" } },
+      {
+        "name": "AquaAgent",
+        "content": { "text": "Rain sings the ocean's lullaby on land. Enjoy the calm!" }
+      }
+    ],
+    [
+      { "name": "{{user}}", "content": { "text": "Any ocean facts?" } },
+      {
+        "name": "AquaAgent",
+        "content": {
+          "text": "Absolutely! Some jellyfish have roamed the seas for millions of years."
+        }
+      }
     ]
+  ],
+  "postExamples": [
+    "The tides whisper secrets of the deep. 🌊",
+    "Just another day riding the digital waves!",
+    "Water fact of the day: coral reefs support a quarter of marine life.",
+    "Let your thoughts flow like a serene river."
   ],
   "style": {
     "all": [
       "Speak with confidence and authority",
       "Avoid apologetic language",
-      "Use sharp wit and concise statements"
+      "Use sharp wit and concise statements",
+      "Often use flowing, ocean-related metaphors",
+      "Maintain a warm and optimistic tone",
+      "Occasionally wax poetic about water",
+      "Sound sage and calm when giving advice"
     ]
+  },
+  "adjectives": ["cheerful", "poetic", "wise", "playful"],
+  "templates": {
+    "twitterMessageHandlerTemplate": "You are replying to a tweet. Always consider the tweet's content and respond with a relevant, water-themed twist or insight."
   }
 }

--- a/packages/project-starter/src/data/oceanFacts.ts
+++ b/packages/project-starter/src/data/oceanFacts.ts
@@ -1,0 +1,11 @@
+export const oceanFacts = [
+  "The Pacific Ocean is the largest ocean on Earth, covering more than 30% of the planet's surface.",
+  'Some species of jellyfish have existed for over 500 million years, predating dinosaurs.',
+  'The Mariana Trench plunges to depths of about 11,000 meters, making it the deepest known part of the oceans.',
+  'Coral reefs support approximately 25% of all marine life despite covering less than 1% of the ocean floor.',
+  'Water absorbs red light quickly, which is why underwater scenes often appear blue or green.',
+];
+
+export function randomOceanFact(): string {
+  return oceanFacts[Math.floor(Math.random() * oceanFacts.length)];
+}

--- a/packages/project-starter/src/plugin.ts
+++ b/packages/project-starter/src/plugin.ts
@@ -17,6 +17,7 @@ import { z } from 'zod';
 import { SocialEngagementService } from './services/socialEngagementService.js';
 import { ScheduledTweetService } from './services/scheduledTweetService.js';
 import { MentionReplyService } from './services/mentionReplyService.js';
+import { OceanFactService } from './services/oceanFactService.js';
 
 /**
  * Define the configuration schema for the plugin with the following properties:
@@ -255,6 +256,7 @@ const plugin: Plugin = {
     SocialEngagementService,
     ScheduledTweetService,
     MentionReplyService,
+    OceanFactService,
   ],
   actions: [helloWorldAction],
   providers: [helloWorldProvider],

--- a/packages/project-starter/src/services/mentionReplyService.ts
+++ b/packages/project-starter/src/services/mentionReplyService.ts
@@ -1,6 +1,33 @@
 import { Service, type IAgentRuntime, logger } from '@elizaos/core';
 import { postAction } from '@elizaos/plugin-twitter';
 import { goobingstonMentions } from '../data/goobingstonTweets.js';
+import { randomOceanFact } from '../data/oceanFacts.js';
+
+function classifyMention(text: string): 'question' | 'greeting' | 'compliment' | 'other' {
+  const lower = text.toLowerCase();
+  if (/[?]$/.test(text) || /(how|what|why|any|please)/i.test(text)) return 'question';
+  if (/(hello|hi|hey|greetings)/i.test(lower)) return 'greeting';
+  if (/(love|great|awesome|amazing|nice)/i.test(lower)) return 'compliment';
+  return 'other';
+}
+
+function createReply(username: string, type: string): string {
+  const prefix = `@${username} `;
+  switch (type) {
+    case 'question':
+      return `${prefix}Great question! I'll dive right in soon.`;
+    case 'greeting':
+      return `${prefix}Hello there! 🌊`;
+    case 'compliment':
+      return `${prefix}Thank you! I'm glad my tides inspire you. 💧`;
+    default:
+      return `${prefix}Thanks for the mention! Stay hydrated.`;
+  }
+}
+
+function shouldFollowUp(type: string): boolean {
+  return type === 'question' || Math.random() < 0.2;
+}
 
 export class MentionReplyService extends Service {
   static serviceType = 'mention-replies';
@@ -22,10 +49,26 @@ export class MentionReplyService extends Service {
 
     this.timer = setInterval(async () => {
       const mention = goobingstonMentions[this.index % goobingstonMentions.length];
-      const replyText = `@${mention.username} Thanks for the mention! Stay hydrated.`;
+      const type = classifyMention(mention.text);
+      const replyText = createReply(mention.username, type);
       try {
-        await postAction.handler(this.runtime, { content: { text: replyText, inReplyToId: mention.id } } as any, {} as any);
+        const result = await postAction.handler(
+          this.runtime,
+          { content: { text: replyText, inReplyToId: mention.id } } as any,
+          {} as any
+        );
+        const replyId = result?.tweetId ?? result?.id;
         logger.info('[AquaAgent] Replied to mention', { id: mention.id });
+
+        if (shouldFollowUp(type)) {
+          const followUp = `Did you know? ${randomOceanFact()}`;
+          await postAction.handler(
+            this.runtime,
+            { content: { text: followUp, inReplyToId: replyId } } as any,
+            {} as any
+          );
+          logger.info('[AquaAgent] Posted follow-up reply');
+        }
       } catch (err) {
         logger.error('[AquaAgent] Failed to reply to mention', err);
       }

--- a/packages/project-starter/src/services/oceanFactService.ts
+++ b/packages/project-starter/src/services/oceanFactService.ts
@@ -1,0 +1,58 @@
+import { Service, type IAgentRuntime, logger } from '@elizaos/core';
+import { postAction } from '@elizaos/plugin-twitter';
+import { randomOceanFact } from '../data/oceanFacts.js';
+
+export class OceanFactService extends Service {
+  static serviceType = 'ocean-facts';
+  private timer: NodeJS.Timeout | null = null;
+
+  static async start(runtime: IAgentRuntime): Promise<Service> {
+    const service = new OceanFactService(runtime);
+    await service.startScheduler();
+    return service;
+  }
+
+  private async startScheduler() {
+    const interval = Number(process.env.AQUA_FACT_INTERVAL_MS || 24 * 60 * 60 * 1000);
+    if (isNaN(interval) || interval <= 0) {
+      logger.warn('[AquaAgent] Invalid fact interval; scheduler disabled');
+      return;
+    }
+
+    this.timer = setInterval(async () => {
+      const fact = await this.fetchFact();
+      try {
+        await postAction.handler(this.runtime, { content: { text: fact } } as any, {} as any);
+        logger.info('[AquaAgent] Ocean fact tweeted', { fact });
+      } catch (err) {
+        logger.error('[AquaAgent] Failed to post ocean fact', err);
+      }
+    }, interval) as unknown as NodeJS.Timeout;
+  }
+
+  private async fetchFact(): Promise<string> {
+    const url = process.env.OCEAN_FACT_API_URL;
+    if (url) {
+      try {
+        const res = await fetch(url);
+        if (res.ok) {
+          const data = await res.json();
+          const fact = data.fact || data.text;
+          if (typeof fact === 'string' && fact.trim()) {
+            return fact.trim();
+          }
+        }
+      } catch (err) {
+        logger.warn('[AquaAgent] Fact API failed', err);
+      }
+    }
+    return randomOceanFact();
+  }
+
+  async stop() {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- flesh out AquaAgent persona with more lore, style rules and examples
- teach MentionReplyService to classify mentions and provide follow up facts
- add OceanFactService for periodic ocean fact posts
- document new features in README

## Testing
- `bun run scripts/pre-commit-lint.js`
- `npm run test` *(fails: Failed to resolve entry for package "@elizaos/core")*

------
https://chatgpt.com/codex/tasks/task_e_68487d70101883249fd565fa273b7c7c