### PR TITLE
Add AquaAgent launch helper

### DIFF
--- a/packages/project-starter/README.md
+++ b/packages/project-starter/README.md
@@ -142,7 +142,13 @@ tone of the response and may include a fun follow-up fact.
 
 ### Launching AquaAgent
 
-To start AquaAgent without manually registering it in the dashboard, run the provided launch script:
+To start AquaAgent without manually registering it in the dashboard, run the provided launch script. A helper shell script is available at `scripts/run-aqua-agent.sh` which sets the recommended environment variables before launching:
+
+```bash
+./scripts/run-aqua-agent.sh
+```
+
+The script simply invokes
 
 ```bash
 bun run src/launchAquaAgent.ts

--- a/scripts/run-aqua-agent.sh
+++ b/scripts/run-aqua-agent.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Launch AquaAgent with environment variables
+set -e
+
+# Default model settings if not already provided
+export LOCAL_LARGE_MODEL="${LOCAL_LARGE_MODEL:-DeepHermes-3-Llama-3-3B-Preview-q4.gguf}"
+export MODELS_DIR="${MODELS_DIR:-$HOME/.eliza/models}"
+
+# Informational output
+echo "Using LOCAL_LARGE_MODEL=$LOCAL_LARGE_MODEL"
+echo "Using MODELS_DIR=$MODELS_DIR"
+
+# Start AquaAgent via the project starter script
+bun run packages/project-starter/src/launchAquaAgent.ts "$@"


### PR DESCRIPTION
## Summary
- add `scripts/run-aqua-agent.sh` to simplify launching AquaAgent with environment variables
- document the new script in the project starter README

## Testing
- `bun run test` *(fails: command not found during plugin bootstrap tests)*

------
https://chatgpt.com/codex/tasks/task_e_68488efc9d30832482256372079fa8b6