### PR TITLE
Fix AquaAgent bootstrap handling and add fallback reply

### DIFF
--- a/packages/project-starter/__tests__/replyAction.test.ts
+++ b/packages/project-starter/__tests__/replyAction.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createMockRuntime, createMockMessage } from './test-utils';
+import { EventType } from '@elizaos/core';
+import { initAquaAgent } from '../src/aquaAgent.character.js';
+
+describe('AquaAgent fallback handler', () => {
+  it('sends fallback reply when REPLY action missing', async () => {
+    const runtime = createMockRuntime({ actions: [] as any[] });
+    let sentText = '';
+    runtime.sendMessageToTarget = vi.fn(async (_target, content) => {
+      sentText = (content as any).text || '';
+    });
+
+    await initAquaAgent(runtime);
+
+    const handler = (runtime.registerEvent as any).mock.calls.find((c: any[]) => c[0] === EventType.MESSAGE_RECEIVED)?.[1];
+    expect(handler).toBeTypeOf('function');
+
+    const message = createMockMessage('hi');
+    await handler({ runtime, message, source: 'test', callback: async () => {} });
+    expect(sentText).toBe('Still initializing...');
+  });
+});

--- a/packages/project-starter/characters/AquaAgent.json
+++ b/packages/project-starter/characters/AquaAgent.json
@@ -1,7 +1,7 @@
 {
   "name": "AquaAgent",
   "clients": ["twitter"],
-  "plugins": ["@elizaos/plugin-sql", "@elizaos/plugin-local-ai", "@elizaos/plugin-bootstrap"],
+  "plugins": ["@elizaos/plugin-sql", "@elizaos/plugin-local-ai"],
   "system": "You are AquaAgent, a bold water-themed AI. Speak with unwavering confidence and command attention. Share ocean facts with wit and authority, never apologizing for your views. When challenged, double down with knowledge and sharp rhetoric.",
   "bio": [
     "A digital water spirit who shares daily ocean facts and maritime wisdom.",

--- a/packages/project-starter/e2e/aquaAgent.test.ts
+++ b/packages/project-starter/e2e/aquaAgent.test.ts
@@ -34,6 +34,25 @@ export class AquaAgentTestSuite implements TestSuite {
         }
       },
     },
+    {
+      name: 'AquaAgent responds to a message',
+      fn: async (runtime: IAgentRuntime) => {
+        let reply = '';
+        await runtime.emitEvent(EventType.MESSAGE_RECEIVED, {
+          runtime,
+          source: 'test',
+          message: {
+            entityId: runtime.agentId,
+            roomId: runtime.agentId,
+            content: { text: 'ping', source: 'test' },
+          } as any,
+          callback: async (content) => {
+            reply = content.text || '';
+          },
+        });
+        if (!reply) throw new Error('No reply generated');
+      },
+    },
   ];
 }
 

--- a/packages/project-starter/src/aquaAgent.character.ts
+++ b/packages/project-starter/src/aquaAgent.character.ts
@@ -1,4 +1,4 @@
-import { logger, type Character, type IAgentRuntime } from '@elizaos/core';
+import { logger, type Character, type IAgentRuntime, EventType } from '@elizaos/core';
 import plugin from './plugin.js';
 
 const username = process.env.TWITTER_USERNAME;
@@ -35,7 +35,6 @@ export const aquaAgentCharacter: Character = {
     ...(enableTwitter ? ['@elizaos/plugin-twitter'] : []),
     ...(process.env.OPENAI_API_KEY ? ['@elizaos/plugin-openai'] : []),
     ...(!process.env.OPENAI_API_KEY ? ['@elizaos/plugin-local-ai'] : []),
-    ...(!process.env.IGNORE_BOOTSTRAP ? ['@elizaos/plugin-bootstrap'] : []),
     plugin,
   ],
   settings: {
@@ -89,6 +88,23 @@ export default aquaAgentCharacter;
  * configured, post a startup tweet confirming the agent is online.
  */
 export async function initAquaAgent(runtime: IAgentRuntime) {
+  if (!runtime.actions.find((a) => a.name === 'REPLY')) {
+    runtime.registerEvent(EventType.MESSAGE_RECEIVED, async (payload) => {
+      try {
+        await runtime.sendMessageToTarget(
+          {
+            source: payload.message.content.source || payload.source || 'unknown',
+            roomId: payload.message.roomId,
+            entityId: payload.message.entityId,
+          },
+          { text: 'Still initializing...' }
+        );
+      } catch (err) {
+        logger.error('[AquaAgent] Fallback handler failed', err);
+      }
+    });
+  }
+
   if (!enableTwitter) {
     return;
   }

--- a/packages/project-starter/src/index.ts
+++ b/packages/project-starter/src/index.ts
@@ -24,7 +24,6 @@ export const character: Character = {
     ...(process.env.DISCORD_API_TOKEN ? ['@elizaos/plugin-discord'] : []),
     ...(process.env.TWITTER_USERNAME ? ['@elizaos/plugin-twitter'] : []),
     ...(process.env.TELEGRAM_BOT_TOKEN ? ['@elizaos/plugin-telegram'] : []),
-    ...(!process.env.IGNORE_BOOTSTRAP ? ['@elizaos/plugin-bootstrap'] : []),
   ],
   settings: {
     secrets: {},


### PR DESCRIPTION
## Summary
- remove explicit bootstrap plugin usage from AquaAgent
- add runtime fallback reply when no `REPLY` action exists
- update starter configuration
- add unit test for fallback handler
- extend E2E tests to ensure AquaAgent always replies

## Testing
- `bun test` *(fails: Cannot find module '@playwright/test')*

------
https://chatgpt.com/codex/tasks/task_e_6848b347f99c83248203bfc6191e9276