### PR TITLE
Add abstract Agent class

### DIFF
--- a/src/agents/Agent.ts
+++ b/src/agents/Agent.ts
@@ -1,0 +1,43 @@
+export interface AgentAdapters<TTwitter = unknown, TTelegram = unknown, TQuickfire = unknown, TMemory = unknown, TStrategy = unknown> {
+  twitter: TTwitter;
+  telegram: TTelegram;
+  quickfire: TQuickfire;
+  memory: TMemory;
+  strategy: TStrategy;
+}
+
+/**
+ * Base abstract Agent class defining lifecycle hooks and dependencies.
+ */
+export default abstract class Agent<A extends AgentAdapters = AgentAdapters> {
+  /** Unique identifier for the agent */
+  public readonly id: string;
+  /** Descriptive persona */
+  public readonly persona: string;
+  /** Mutable internal state */
+  public readonly state: Record<string, unknown>;
+
+  protected readonly adapters: A;
+
+  constructor(id: string, persona: string, state: Record<string, unknown>, adapters: A) {
+    this.id = id;
+    this.persona = persona;
+    this.state = state;
+    this.adapters = adapters;
+  }
+
+  /**
+   * Perform internal reasoning steps.
+   */
+  abstract think(): Promise<void>;
+
+  /**
+   * Determine actions based on current state.
+   */
+  abstract plan(): Promise<void>;
+
+  /**
+   * Execute the previously determined plan.
+   */
+  abstract act(): Promise<void>;
+}

--- a/tests/Agent.test.ts
+++ b/tests/Agent.test.ts
@@ -1,0 +1,23 @@
+import Agent, { AgentAdapters } from '../src/agents/Agent';
+
+class DummyAgent extends Agent {
+  async think(): Promise<void> {}
+  async plan(): Promise<void> {}
+  async act(): Promise<void> {}
+}
+
+describe('Agent', () => {
+  it('stores provided initialization data', () => {
+    const adapters: AgentAdapters = {
+      twitter: {},
+      telegram: {},
+      quickfire: {},
+      memory: {},
+      strategy: {},
+    };
+    const agent = new DummyAgent('1', 'persona', {}, adapters);
+    expect(agent.id).toBe('1');
+    expect(agent.persona).toBe('persona');
+    expect(agent.state).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
- add an abstract `Agent` class with dependency injected adapters
- scaffold Jest tests for the new class

## Testing
- `bun run test` *(fails: turbo command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848f2741750832489f137bd0ac9ae04