### PR TITLE
Use initial_offset for scheduler

### DIFF
--- a/scheduler/tasks.py
+++ b/scheduler/tasks.py
@@ -1,7 +1,7 @@
 import asyncio
 import random
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
@@ -29,10 +29,11 @@ def build_scheduler(agent_runtimes):
 
     for rt in agent_runtimes:
         initial_offset = random.randint(0, 300)
+        next_run = datetime.utcnow() + timedelta(seconds=initial_offset)
         sched.add_job(
             rt.periodic_post,
             trigger=IntervalTrigger(minutes=30, start_date=datetime.utcnow(), jitter=120),
-            next_run_time=datetime.utcnow(),
+            next_run_time=next_run,
             id=f"{rt.agent.name}-post",
         )
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import types
+from datetime import datetime, timedelta
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import scheduler.tasks as tasks
+
+class DummyRuntime:
+    def __init__(self, name="TestAgent"):
+        self.agent = types.SimpleNamespace(name=name)
+    async def periodic_post(self):
+        pass
+    async def monitor_mentions(self):
+        pass
+
+def test_build_scheduler_uses_initial_offset(monkeypatch):
+    fixed_now = datetime(2024, 1, 1, 0, 0, 0)
+
+    class DummyDateTime(datetime):
+        @classmethod
+        def utcnow(cls):
+            return fixed_now
+
+    monkeypatch.setattr(tasks, "datetime", DummyDateTime)
+    monkeypatch.setattr(tasks.random, "randint", lambda a, b: 42)
+
+    rt = DummyRuntime()
+    sched = tasks.build_scheduler([rt])
+    job = sched.get_job(f"{rt.agent.name}-post")
+    expected = (fixed_now + timedelta(seconds=42)).replace(tzinfo=tasks.timezone.utc)
+    assert job.next_run_time == expected


### PR DESCRIPTION
## Summary
- offset agent first posts using `initial_offset`
- test scheduler's initial run time

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f5f769eec83248bc9bd17e8dd4e90