### PR TITLE
Add dry run flag to Twitter bot

### DIFF
--- a/agents/base.py
+++ b/agents/base.py
@@ -15,6 +15,7 @@ class TwitterAgent:
     idx: int
     name: str
     personality: str
+    dry_run: bool = False
     api_key: Optional[str] = field(repr=False, default=None)
     api_secret: Optional[str] = field(repr=False, default=None)
     access_token: Optional[str] = field(repr=False, default=None)
@@ -23,7 +24,10 @@ class TwitterAgent:
 
     def __post_init__(self) -> None:
         self._load_creds_from_env()
-        self.authenticate()
+        if not self.dry_run:
+            self.authenticate()
+        else:
+            log.info("%s running in dry run mode", self.name)
 
     def _load_creds_from_env(self) -> None:
         if not self.api_key:
@@ -34,6 +38,9 @@ class TwitterAgent:
             self.access_secret = os.getenv(prefix + "ACCESS_SECRET")
 
     def authenticate(self) -> None:
+        if self.dry_run:
+            log.info("%s authenticate skipped (dry run)", self.name)
+            return
         auth = tweepy.OAuth1UserHandler(
             self.api_key,
             self.api_secret,
@@ -48,6 +55,9 @@ class TwitterAgent:
 
     @retry(wait=wait_random_exponential(multiplier=2, max=60), stop=stop_after_attempt(5), reraise=True)
     def post(self, text: str) -> int:
+        if self.dry_run:
+            log.info("%s post skipped (dry run): %s", self.name, text)
+            return -1
         status = self.client.update_status(status=text)
         tweet_id = status.id
         log.info("%s posted tweet %s", self.name, tweet_id)
@@ -55,6 +65,11 @@ class TwitterAgent:
 
     @retry(wait=wait_random_exponential(multiplier=2, max=60), stop=stop_after_attempt(5), reraise=True)
     def reply(self, text: str, tweet_id: int) -> int:
+        if self.dry_run:
+            log.info(
+                "%s reply skipped (dry run) to %s: %s", self.name, tweet_id, text
+            )
+            return -1
         status = self.client.update_status(
             status=text,
             in_reply_to_status_id=tweet_id,
@@ -65,6 +80,9 @@ class TwitterAgent:
         return reply_id
 
     async def check_mentions(self, since_id: Optional[int] = None) -> int:
+        if self.dry_run:
+            log.info("%s check_mentions skipped (dry run)", self.name)
+            return since_id or 1
         timeline = self.client.mentions_timeline(
             since_id=since_id, tweet_mode="extended", count=20
         )

--- a/run.py
+++ b/run.py
@@ -23,17 +23,21 @@ def _has_creds(idx: int) -> bool:
     return all(os.getenv(prefix + k) for k in keys)
 
 
-def init_agents():
+def init_agents(dry_run: bool = False):
     agents = []
     for idx in range(1, NUM_AGENTS + 1):
         if not _has_creds(idx):
-            log.info("Agent%d skipped - no creds", idx)
-            continue
+            if dry_run:
+                log.info("Agent%d using dry run (no creds)", idx)
+            else:
+                log.info("Agent%d skipped - no creds", idx)
+                continue
         agents.append(
             TwitterAgent(
                 idx=idx,
                 name=f"Agent{idx}",
                 personality=PERSONALITIES[idx - 1],
+                dry_run=dry_run,
             )
         )
     return agents
@@ -47,9 +51,14 @@ async def main():
         action="store_true",
         help="post once and self-reply for each agent then exit",
     )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="skip API calls and operate without credentials",
+    )
     args = parser.parse_args()
 
-    agent_runtimes = [AgentRuntime(a) for a in init_agents()]
+    agent_runtimes = [AgentRuntime(a) for a in init_agents(dry_run=args.dry_run)]
 
     if args.demo:
         for rt in agent_runtimes:

--- a/tests/test_twitter_agents.py
+++ b/tests/test_twitter_agents.py
@@ -90,3 +90,27 @@ def test_post_returns_int(monkeypatch, once_mode):
     agent.client = DummyClient()
     tweet_id = agent.post("hi")
     assert isinstance(tweet_id, int) and tweet_id > 0
+
+
+def test_dry_run_skips_post_and_reply(monkeypatch):
+    agent = TwitterAgent(
+        idx=2,
+        name="AgentDR",
+        personality="demo",
+        dry_run=True,
+    )
+
+    class DummyClient:
+        def __init__(self):
+            self.called = False
+
+        def update_status(self, **_kwargs):
+            self.called = True
+
+    agent.client = DummyClient()
+    post_id = agent.post("hi")
+    reply_id = agent.reply("reply", 123)
+
+    assert post_id == -1
+    assert reply_id == -1
+    assert agent.client.called is False


### PR DESCRIPTION
## Summary
- add `dry_run` support to `TwitterAgent`
- support `--dry-run` flag in runner script
- test dry run behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f5f7778888324bcad5be96168a385