### PR TITLE
Fix Twitter posting with v2 API

### DIFF
--- a/agents/base.py
+++ b/agents/base.py
@@ -41,14 +41,27 @@ class TwitterAgent:
         if self.dry_run:
             log.info("%s authenticate skipped (dry run)", self.name)
             return
-        auth = tweepy.OAuth1UserHandler(
+        # ---------- OAuth 1.0a (needed for user-context writes) ----------
+        self._auth = tweepy.OAuth1UserHandler(
             self.api_key,
             self.api_secret,
             self.access_token,
             self.access_secret,
         )
-        self.client = tweepy.API(auth, wait_on_rate_limit=True)
-        log.info("%s authenticated", self.name)
+
+        # v1.1 client (read-only for free tier)
+        self.api_v1 = tweepy.API(self._auth, wait_on_rate_limit=True)
+
+        # v2 client (write + read, same creds)
+        self.client = tweepy.Client(
+            consumer_key=self.api_key,
+            consumer_secret=self.api_secret,
+            access_token=self.access_token,
+            access_token_secret=self.access_secret,
+            wait_on_rate_limit=True,
+        )
+
+        log.info("%s authenticated (v1 read, v2 write)", self.name)
 
     def craft_post(self) -> str:
         return f"{self.name} says hello in a {self.personality} manner."
@@ -58,8 +71,8 @@ class TwitterAgent:
         if self.dry_run:
             log.info("%s post skipped (dry run): %s", self.name, text)
             return -1
-        status = self.client.update_status(status=text)
-        tweet_id = status.id
+        resp = self.client.create_tweet(text=text)
+        tweet_id = resp.data["id"]
         log.info("%s posted tweet %s", self.name, tweet_id)
         return tweet_id
 
@@ -70,12 +83,11 @@ class TwitterAgent:
                 "%s reply skipped (dry run) to %s: %s", self.name, tweet_id, text
             )
             return -1
-        status = self.client.update_status(
-            status=text,
-            in_reply_to_status_id=tweet_id,
-            auto_populate_reply_metadata=True,
+        resp = self.client.create_tweet(
+            text=text,
+            in_reply_to_tweet_id=tweet_id,
         )
-        reply_id = status.id
+        reply_id = resp.data["id"]
         log.info("%s replied with %s", self.name, reply_id)
         return reply_id
 
@@ -83,7 +95,7 @@ class TwitterAgent:
         if self.dry_run:
             log.info("%s check_mentions skipped (dry run)", self.name)
             return since_id or 1
-        timeline = self.client.mentions_timeline(
+        timeline = self.api_v1.mentions_timeline(
             since_id=since_id, tweet_mode="extended", count=20
         )
         new_since = since_id or 1
@@ -91,10 +103,9 @@ class TwitterAgent:
             new_since = max(status.id, new_since)
             text = f"@{status.user.screen_name} {self.name} replies in a {self.personality} style."
             try:
-                self.client.update_status(
-                    status=text,
-                    in_reply_to_status_id=status.id,
-                    auto_populate_reply_metadata=True,
+                self.client.create_tweet(
+                    text=text,
+                    in_reply_to_tweet_id=status.id,
                 )
                 log.info("%s replied to %s", self.name, status.id)
             except tweepy.TweepyException as exc:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tweepy>=4.15,<5
+tweepy>=4.16,<5
 APScheduler>=3.10,<4
 python-dotenv>=1.0,<2
 tenacity>=8.2,<9

--- a/tests/test_twitter_agents.py
+++ b/tests/test_twitter_agents.py
@@ -16,8 +16,15 @@ sys.modules.setdefault(
             (),
             {
                 "__init__": lambda self, *a, **k: None,
-                "update_status": lambda *a, **k: None,
                 "mentions_timeline": lambda *a, **k: [],
+            },
+        ),
+        Client=type(
+            "Client",
+            (),
+            {
+                "__init__": lambda self, *a, **k: None,
+                "create_tweet": lambda self, **_k: types.SimpleNamespace(data={"id": 123}),
             },
         ),
         TweepyException=Exception,
@@ -79,13 +86,13 @@ def test_post_returns_int(monkeypatch, once_mode):
         access_secret="ts",
     )
 
-    class DummyStatus:
+    class DummyResponse:
         def __init__(self, id):
-            self.id = id
+            self.data = {"id": id}
 
     class DummyClient:
-        def update_status(self, **kwargs):
-            return DummyStatus(123)
+        def create_tweet(self, **_kwargs):
+            return DummyResponse(123)
 
     agent.client = DummyClient()
     tweet_id = agent.post("hi")
@@ -104,7 +111,7 @@ def test_dry_run_skips_post_and_reply(monkeypatch):
         def __init__(self):
             self.called = False
 
-        def update_status(self, **_kwargs):
+        def create_tweet(self, **_kwargs):
             self.called = True
 
     agent.client = DummyClient()


### PR DESCRIPTION
## Summary
- support Twitter v2 posting by using `tweepy.Client.create_tweet`
- keep v1 client for mentions
- bump Tweepy requirement
- update tests for new Tweepy client

## Testing
- `pytest -q`
- `bun install` *(fails: Duplicate package path & registry.npmjs.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684f76bdbdac8324bc35e5fb8d91a12e