### PR TITLE
Add dry-run support and smoke test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,5 +10,6 @@ REPLY_DELAY_MIN=5
 REPLY_DELAY_MAX=20
 # optional
 OPENAI_API_KEY=
+# DRY_RUN=true  # set for local testing without posting
 
 # repeat up to 18 …

--- a/agents/base.py
+++ b/agents/base.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from datetime import datetime, timedelta
 from dataclasses import dataclass, field
 from typing import Optional
+import time
 
 import quickfire
 
@@ -43,6 +44,7 @@ def _record_tweet(text: str) -> None:
     h = _tweet_hash(text)
     _db.execute("INSERT OR IGNORE INTO tweets(text) VALUES(?)", (h,))
     _db.commit()
+
 
 @dataclass
 class TwitterAgent:
@@ -115,22 +117,29 @@ class TwitterAgent:
     def craft_reply(self, original_text: str) -> str:
         return quickfire.create_reply(self.personality, original_text)
 
-    @retry(wait=wait_random_exponential(multiplier=2, max=60), stop=stop_after_attempt(5), reraise=True)
-    def post(self, text: str) -> int:
+    @retry(
+        wait=wait_random_exponential(multiplier=2, max=60),
+        stop=stop_after_attempt(5),
+        reraise=True,
+    )
+    def post(self, text: str, *, dry_run: Optional[bool] = None) -> int:
+        if dry_run is None:
+            dry_run = self.dry_run
         if _is_duplicate(text):
             log.info(
                 "duplicate avoided",
                 extra={"agent": self.name, "event": "duplicate"},
             )
             return -1
-        if self.dry_run:
+        if dry_run:
             log.info(
-                "%s post skipped (dry run): %s",
+                "%s would post: %s",
                 self.name,
                 text,
-                extra={"agent": self.name, "event": "post_skip"},
+                extra={"agent": self.name, "event": "dry_run"},
             )
-            return -1
+            _record_tweet(text)
+            return int(time.time() * 1000)
         resp = self.client.create_tweet(text=text)
         tweet_id = resp.data["id"]
         log.info(
@@ -142,24 +151,32 @@ class TwitterAgent:
         _record_tweet(text)
         return tweet_id
 
-    @retry(wait=wait_random_exponential(multiplier=2, max=60), stop=stop_after_attempt(5), reraise=True)
+    @retry(
+        wait=wait_random_exponential(multiplier=2, max=60),
+        stop=stop_after_attempt(5),
+        reraise=True,
+    )
     def reply(
         self,
         tweet_id: int,
         text: Optional[str] = None,
         original_text: Optional[str] = None,
+        *,
+        dry_run: Optional[bool] = None,
     ) -> int:
         if text is None:
             text = self.craft_reply(original_text or "")
-        if self.dry_run:
+        if dry_run is None:
+            dry_run = self.dry_run
+        if dry_run:
             log.info(
-                "%s reply skipped (dry run) to %s: %s",
+                "%s would reply to %s: %s",
                 self.name,
                 tweet_id,
                 text,
-                extra={"agent": self.name, "event": "reply_skip"},
+                extra={"agent": self.name, "event": "dry_run"},
             )
-            return -1
+            return int(time.time() * 1000)
         resp = self.client.create_tweet(text=text, in_reply_to_tweet_id=tweet_id)
         reply_id = resp.data["id"]
         log.info(

--- a/quickfire.py
+++ b/quickfire.py
@@ -1,5 +1,5 @@
-import os
 import logging
+import os
 import random
 from typing import Optional
 
@@ -9,16 +9,20 @@ log = logging.getLogger("quickfire")
 HASH_TAGS = ["#Alpha", "#CryptoLife", "#OnChain", "#MemeMagic"]
 
 
+def is_live() -> bool:
+    """Return True if OPENAI_API_KEY is configured."""
+    return bool(os.getenv("OPENAI_API_KEY"))
+
+
 def _get_openai() -> Optional[object]:
-    key = os.getenv("OPENAI_API_KEY")
-    if not key:
+    if not is_live():
         return None
     try:
         import openai  # type: ignore
     except ImportError:
         log.warning("openai package not installed; using stub responses")
         return None
-    openai.api_key = key
+    openai.api_key = os.getenv("OPENAI_API_KEY")
     return openai
 
 
@@ -33,9 +37,20 @@ def create_post(persona: str) -> str:
             model="gpt-3.5-turbo",
             messages=[{"role": "user", "content": prompt}],
         )
+        usage = resp.get("usage", {})
+        log.info(
+            "openai cost",
+            extra={
+                "event": "openai_cost",
+                "completion_tokens": usage.get("completion_tokens", 0),
+                "prompt_tokens": usage.get("prompt_tokens", 0),
+            },
+        )
         text = resp.choices[0].message["content"].strip()
     # Add flavour with hashtags and emojis
-    text += " " + random.choice(HASH_TAGS) + " " + random.choice(["🔥", "⚡", "🚀", "✨"])
+    text += (
+        " " + random.choice(HASH_TAGS) + " " + random.choice(["🔥", "⚡", "🚀", "✨"])
+    )
     return text
 
 
@@ -44,12 +59,18 @@ def create_reply(persona: str, original: str) -> str:
     openai = _get_openai()
     if not openai:
         return f"[stub] 🤝 {persona} agrees"
-    prompt = (
-        f"Reply to the following tweet in a {persona} voice, be witty, max 200 chars.\n\nORIGINAL: {original}"
-    )
+    prompt = f"Reply to the following tweet in a {persona} voice, be witty, max 200 chars.\n\nORIGINAL: {original}"
     resp = openai.ChatCompletion.create(
         model="gpt-3.5-turbo",
         messages=[{"role": "user", "content": prompt}],
     )
+    usage = resp.get("usage", {})
+    log.info(
+        "openai cost",
+        extra={
+            "event": "openai_cost",
+            "completion_tokens": usage.get("completion_tokens", 0),
+            "prompt_tokens": usage.get("prompt_tokens", 0),
+        },
+    )
     return resp.choices[0].message["content"].strip()
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-dotenv>=1.0,<2
 tenacity>=8.2,<9
 pyyaml>=6.0
 python-json-logger>=2.0
+rich>=13

--- a/run.py
+++ b/run.py
@@ -26,7 +26,7 @@ log = logging.getLogger("runner")
 REPLY_DELAY_MIN = int(os.getenv("REPLY_DELAY_MIN", "5"))
 REPLY_DELAY_MAX = int(os.getenv("REPLY_DELAY_MAX", "20"))
 
-NUM_AGENTS = 18
+NUM_AGENTS = int(os.getenv("NUM_AGENTS", "18"))
 
 
 def _has_creds(idx: int) -> bool:
@@ -70,15 +70,21 @@ async def main():
     )
     args = parser.parse_args()
 
-    agent_runtimes = [AgentRuntime(a) for a in init_agents(dry_run=args.dry_run)]
+    if args.dry_run:
+        log.info("dry run mode", extra={"event": "dry_run"})
+    agent_runtimes = [
+        AgentRuntime(a, dry_run=args.dry_run) for a in init_agents(dry_run=args.dry_run)
+    ]
 
     if args.demo:
         for rt in agent_runtimes:
             text = rt.agent.craft_post()
-            tweet_id = rt.agent.post(text)
+            tweet_id = rt.agent.post(text, dry_run=args.dry_run)
             if tweet_id != -1:
                 await asyncio.sleep(random.uniform(REPLY_DELAY_MIN, REPLY_DELAY_MAX))
-                rt.agent.reply(tweet_id=tweet_id, original_text=text)
+                rt.agent.reply(
+                    tweet_id=tweet_id, original_text=text, dry_run=args.dry_run
+                )
         return
 
     if args.once:

--- a/scheduler/tasks.py
+++ b/scheduler/tasks.py
@@ -12,23 +12,28 @@ log = logging.getLogger("sched")
 REPLY_DELAY_MIN = int(os.getenv("REPLY_DELAY_MIN", "5"))
 REPLY_DELAY_MAX = int(os.getenv("REPLY_DELAY_MAX", "20"))
 
+
 class AgentRuntime:
-    def __init__(self, agent):
+    def __init__(self, agent, dry_run: bool = False):
         self.agent = agent
+        self.dry_run = dry_run
         self.last_mention_id = None
 
     async def periodic_post(self):
         text = self.agent.craft_post()
-        tweet_id = self.agent.post(text)
+        tweet_id = self.agent.post(text, dry_run=self.dry_run)
         if tweet_id != -1:
             await asyncio.sleep(random.uniform(REPLY_DELAY_MIN, REPLY_DELAY_MAX))
-            self.agent.reply(tweet_id=tweet_id, original_text=text)
+            self.agent.reply(
+                tweet_id=tweet_id, original_text=text, dry_run=self.dry_run
+            )
 
     async def monitor_mentions(self):
         self.last_mention_id = await self.agent.check_mentions(
             since_id=self.last_mention_id
         )
         await asyncio.sleep(0)
+
 
 def build_scheduler(agent_runtimes):
     sched = AsyncIOScheduler(timezone=timezone.utc)
@@ -38,7 +43,9 @@ def build_scheduler(agent_runtimes):
         next_run = datetime.utcnow() + timedelta(seconds=initial_offset)
         sched.add_job(
             rt.periodic_post,
-            trigger=IntervalTrigger(minutes=30, start_date=datetime.utcnow(), jitter=120),
+            trigger=IntervalTrigger(
+                minutes=30, start_date=datetime.utcnow(), jitter=120
+            ),
             next_run_time=next_run,
             id=f"{rt.agent.name}-post",
         )

--- a/scripts/smoke.py
+++ b/scripts/smoke.py
@@ -1,0 +1,57 @@
+"""
+Usage: python scripts/smoke.py
+
+Runs:
+  1) python run.py --demo --dry-run      # should hit duplicate guard second run
+  2) python run.py --demo                # real tweets if creds + OPENAI key
+
+Prints a colourized summary (use rich.print) of:
+  ✔ post success
+  ✔ reply success
+  ✔ duplicate skip
+"""
+
+import os
+import socket
+import subprocess
+import sys
+from rich import print
+
+
+def run(cmd):
+    result = subprocess.run([sys.executable] + cmd, capture_output=True, text=True)
+    return result.stdout + result.stderr
+
+
+def main() -> None:
+    log1 = run(["run.py", "--demo", "--dry-run"])
+    log2 = run(["run.py", "--demo", "--dry-run"])
+
+    post_ok = "dry_run" in log1
+    reply_ok = "dry_run" in log1
+    dup_ok = "duplicate" in log2
+
+    have_net = False
+    try:
+        socket.create_connection(("api.twitter.com", 443), timeout=2)
+        have_net = True
+    except OSError:
+        pass
+
+    if os.getenv("TWITTER_AGENT1_API_KEY") and have_net:
+        run(["run.py", "--demo"])
+
+    status = [
+        (post_ok, "post success"),
+        (reply_ok, "reply success"),
+        (dup_ok, "duplicate skip"),
+    ]
+    for ok, label in status:
+        if ok:
+            print(f"[green]✔ {label}[/green]")
+        else:
+            print(f"[red]✖ {label}[/red]")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_twitter_agents.py
+++ b/tests/test_twitter_agents.py
@@ -1,5 +1,7 @@
 import os
 import sys
+import asyncio
+import subprocess
 import pytest
 import types
 import sqlite3
@@ -25,7 +27,9 @@ sys.modules.setdefault(
             (),
             {
                 "__init__": lambda self, *a, **k: None,
-                "create_tweet": lambda self, **_k: types.SimpleNamespace(data={"id": 123}),
+                "create_tweet": lambda self, **_k: types.SimpleNamespace(
+                    data={"id": 123}
+                ),
             },
         ),
         TweepyException=Exception,
@@ -41,7 +45,7 @@ sys.modules.setdefault(
 )
 
 # Ensure module import
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from agents.base import TwitterAgent
 import quickfire
@@ -65,6 +69,7 @@ def stub_quickfire(monkeypatch):
 @pytest.fixture(autouse=True)
 def temp_db(tmp_path, monkeypatch):
     import agents.base as base
+
     monkeypatch.setattr(base, "DB_PATH", tmp_path / "db.sqlite", raising=False)
     base._db = sqlite3.connect(base.DB_PATH)
     base._db.execute(
@@ -194,6 +199,18 @@ def test_dry_run_skips_post_and_reply(monkeypatch):
     post_id = agent.post("hi")
     reply_id = agent.reply(tweet_id=123, text="reply")
 
-    assert post_id == -1
-    assert reply_id == -1
+    assert post_id > 0
+    assert reply_id > 0
     assert agent.client.called is False
+
+
+def test_cli_dry_run_event(tmp_path):
+    env = os.environ.copy()
+    env.update({"REPLY_DELAY_MIN": "0", "REPLY_DELAY_MAX": "0"})
+    result = subprocess.run(
+        [sys.executable, "run.py", "--demo", "--dry-run"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert '"event": "dry_run"' in result.stdout + result.stderr


### PR DESCRIPTION
## Summary
- support --dry-run CLI option propagated through scheduler and agents
- add OpenAI cost logging and is_live helper
- implement fast validation smoke script
- add test coverage for dry-run mode
- document dry-run in .env.example

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `NUM_AGENTS=1 python scripts/smoke.py`

------
https://chatgpt.com/codex/tasks/task_e_684f938978d48324a10a4e54e1c46706