### PR TITLE
Add AQUA_HASHTAGS override for quickfire

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,18 @@ INSTRUMENTATION_ENABLED=true
 POSTGRES_URL_INSTRUMENTATION="postgresql://postgres:postgres@localhost:5432/eliza_tracing"
 ```
 
+### Quickfire Hashtags
+
+You can override the default hashtags used by the `quickfire` helper by setting
+the `AQUA_HASHTAGS` environment variable:
+
+```bash
+export AQUA_HASHTAGS="#Foo,#Bar,#Baz"
+```
+
+If provided, these comma-separated tags will be chosen instead of the built in
+defaults.
+
 ---
 
 ### Automatically Start Eliza

--- a/quickfire.py
+++ b/quickfire.py
@@ -1,12 +1,25 @@
 import logging
 import os
 import random
-from typing import Optional
+from typing import List, Optional
 
 log = logging.getLogger("quickfire")
 
-# Hashtags used to spice up posts
-HASH_TAGS = ["#Alpha", "#CryptoLife", "#OnChain", "#MemeMagic"]
+# Default hashtags used to spice up posts
+DEFAULT_HASH_TAGS = ["#Alpha", "#CryptoLife", "#OnChain", "#MemeMagic"]
+
+# Environment variable for overriding hashtags
+_HASHTAG_ENV = "AQUA_HASHTAGS"
+
+
+def _get_hashtags() -> List[str]:
+    """Return hashtags from the environment variable if provided."""
+    env_val = os.getenv(_HASHTAG_ENV)
+    if env_val:
+        tags = [t.strip() for t in env_val.split(",") if t.strip()]
+        if tags:
+            return tags
+    return DEFAULT_HASH_TAGS
 
 
 def is_live() -> bool:
@@ -47,9 +60,10 @@ def create_post(persona: str) -> str:
             },
         )
         text = resp.choices[0].message["content"].strip()
+    hashtags = _get_hashtags()
     # Add flavour with hashtags and emojis
     text += (
-        " " + random.choice(HASH_TAGS) + " " + random.choice(["🔥", "⚡", "🚀", "✨"])
+        " " + random.choice(hashtags) + " " + random.choice(["🔥", "⚡", "🚀", "✨"])
     )
     return text
 

--- a/tests/test_quickfire.py
+++ b/tests/test_quickfire.py
@@ -1,0 +1,15 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import quickfire
+
+
+def test_env_overrides_hashtags(monkeypatch):
+    monkeypatch.setenv("AQUA_HASHTAGS", "#Foo,#Bar")
+    monkeypatch.setattr(quickfire, "_get_openai", lambda: None)
+    monkeypatch.setattr(quickfire.random, "choice", lambda seq: seq[0])
+    text = quickfire.create_post("demo")
+    assert "#Foo" in text
+


### PR DESCRIPTION
## Summary
- allow `quickfire` to read hashtags from `AQUA_HASHTAGS`
- document the new env variable in the README
- test that the variable overrides defaults

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f9d2195e08324ae5f7e35de6056f1