### PR TITLE
Update setup docs and CI for dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,10 @@ jobs:
         with:
           node-version: '23'
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - name: Cache Bun dependencies
         uses: actions/cache@v4
         with:
@@ -64,6 +68,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '23'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
 
       - name: Restore dependencies
         uses: actions/cache/restore@v4
@@ -76,8 +83,14 @@ jobs:
           echo "TEST_DATABASE_CLIENT=pglite" > packages/core/.env.test
           echo "NODE_ENV=test" >> packages/core/.env.test
 
-      - name: Run tests
-        run: cd packages/core && bun test:coverage
+      - name: Install Python dependencies
+        run: python -m pip install -r requirements.txt
+
+      - name: Run Node tests
+        run: bun run test
+
+      - name: Run Python tests
+        run: pytest -vv
 
   # Lint and format job - runs in parallel
   lint-and-format:

--- a/README.md
+++ b/README.md
@@ -87,6 +87,20 @@ cp .env.example .env
 
 Note: .env is optional. If you're planning to run multiple distinct agents, you can pass secrets through the character JSON
 
+#### Install Python Dependencies
+
+Some features, including the scheduler and Python-based tests, require additional Python packages such as `APScheduler`. Install them with:
+
+```bash
+pip install -r requirements.txt
+```
+
+You can also run the `setup.sh` script, which installs both Node dependencies (including `turbo`) and these Python requirements:
+
+```bash
+bash setup.sh
+```
+
 #### Start Eliza
 
 Important! We now use Bun. If you are using npm, you will need to install Bun:

--- a/setup.sh
+++ b/setup.sh
@@ -97,6 +97,16 @@ install_dependencies() {
     bun install
 }
 
+# Function to install Python dependencies
+install_python_dependencies() {
+    if command_exists python3; then
+        print_message "$YELLOW" "Installing Python dependencies..."
+        python3 -m pip install -r requirements.txt
+    else
+        print_message "$RED" "Python3 is not installed. Skipping Python dependency installation."
+    fi
+}
+
 # Function to build the project
 build_project() {
     print_message "$YELLOW" "Building project..."
@@ -145,6 +155,9 @@ create_config_files
 # Install dependencies
 install_dependencies
 
+# Install Python dependencies
+install_python_dependencies
+
 # Build the project
 build_project
 
@@ -161,3 +174,6 @@ print_message "$YELLOW" "Note: Make sure to configure your .env file with the ne
 # Show Docker status
 if ! check_docker; then
     print_message "$BLUE" "Some features may require Docker. You can install it later and run 'docker-compose up' to enable those features." 
+fi
+
+


### PR DESCRIPTION
## Summary
- add instructions for installing Python dependencies
- extend setup script to install Python packages
- install Node and Python deps during CI and run tests

## Testing
- `bun run test` *(fails: turbo not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684f9d23de908324a95eca86f4c79b39