### PR TITLE
Add demo mode logging

### DIFF
--- a/run.py
+++ b/run.py
@@ -80,10 +80,29 @@ async def main():
         for rt in agent_runtimes:
             text = rt.agent.craft_post()
             tweet_id = rt.agent.post(text, dry_run=args.dry_run)
+            log.info(
+                "demo post", 
+                extra={
+                    "agent": rt.agent.name,
+                    "event": "demo_post",
+                    "post_id": tweet_id,
+                    "text": text,
+                },
+            )
             if tweet_id != -1:
                 await asyncio.sleep(random.uniform(REPLY_DELAY_MIN, REPLY_DELAY_MAX))
-                rt.agent.reply(
-                    tweet_id=tweet_id, original_text=text, dry_run=args.dry_run
+                reply_text = rt.agent.craft_reply(text)
+                reply_id = rt.agent.reply(
+                    tweet_id=tweet_id, text=reply_text, dry_run=args.dry_run
+                )
+                log.info(
+                    "demo reply",
+                    extra={
+                        "agent": rt.agent.name,
+                        "event": "demo_reply",
+                        "reply_id": reply_id,
+                        "text": reply_text,
+                    },
                 )
         return
 

--- a/tests/test_twitter_agents.py
+++ b/tests/test_twitter_agents.py
@@ -214,3 +214,17 @@ def test_cli_dry_run_event(tmp_path):
         env=env,
     )
     assert '"event": "dry_run"' in result.stdout + result.stderr
+
+
+def test_cli_demo_logging(tmp_path):
+    env = os.environ.copy()
+    env.update({"REPLY_DELAY_MIN": "0", "REPLY_DELAY_MAX": "0"})
+    result = subprocess.run(
+        [sys.executable, "run.py", "--demo", "--dry-run"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    out = result.stdout + result.stderr
+    assert '"event": "demo_post"' in out
+    assert '"event": "demo_reply"' in out


### PR DESCRIPTION
## Summary
- log post text and tweet ID after posting in demo mode
- log reply text and ID after replying in demo mode
- test for demo logging in CLI demo mode

## Testing
- `pytest -q`
- `npm test --silent` *(fails: turbo not found)*
- `bun install` *(fails: duplicate package path)*

------
https://chatgpt.com/codex/tasks/task_e_684f9d260d988324becad346ddd8fd48