### PR TITLE
Add log for missing OPENAI key

### DIFF
--- a/quickfire.py
+++ b/quickfire.py
@@ -16,6 +16,7 @@ def is_live() -> bool:
 
 def _get_openai() -> Optional[object]:
     if not is_live():
+        log.info("OPENAI_API_KEY not set; using OpenAI fallback stub")
         return None
     try:
         import openai  # type: ignore

--- a/tests/smoke_demo.py
+++ b/tests/smoke_demo.py
@@ -53,7 +53,8 @@ def test_demo_smoke(monkeypatch, tmp_path, caplog):
     assert "duplicate avoided" in log2
 
     # 2. OpenAI fallback stub is used
-    assert "OpenAI fallback stub" in log1 or "OpenAI fallback stub" in log2
+    expected = "OPENAI_API_KEY not set; using OpenAI fallback stub"
+    assert expected in log1 or expected in log2
 
     # 3. Reply delay is between 1 and 2 seconds
     assert any(1 <= float(secs) <= 2 for secs in sleep_calls), f"Delays: {sleep_calls}"


### PR DESCRIPTION
## Summary
- log an info message when OPENAI_API_KEY is not set
- check for the log line in demo smoke test

## Testing
- `pytest -q`
- `bun run test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f9d2ab6788324ad07d7c391594d22