### PR TITLE
Fix reply generation in demo mode

### DIFF
--- a/run.py
+++ b/run.py
@@ -81,9 +81,15 @@ async def main():
             text = rt.agent.craft_post()
             tweet_id = rt.agent.post(text, dry_run=args.dry_run)
             if tweet_id != -1:
-                await asyncio.sleep(random.uniform(REPLY_DELAY_MIN, REPLY_DELAY_MAX))
+                await asyncio.sleep(
+                    random.uniform(REPLY_DELAY_MIN, REPLY_DELAY_MAX)
+                )
+                reply_text = rt.agent.craft_reply(text)
                 rt.agent.reply(
-                    tweet_id=tweet_id, original_text=text, dry_run=args.dry_run
+                    tweet_id=tweet_id,
+                    text=reply_text,
+                    original_text=text,
+                    dry_run=args.dry_run,
                 )
         return
 


### PR DESCRIPTION
## Summary
- ensure demo mode replies use `craft_reply`
- pass post text when crafting replies to keep context

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f9d2bd3e8832499e7816bdc81a862