### PR TITLE
Remove credential prints from runner

### DIFF
--- a/run.py
+++ b/run.py
@@ -12,16 +12,12 @@ from agents.personalities import PERSONALITIES
 from scheduler.tasks import AgentRuntime, build_scheduler
 
 load_dotenv()
-print("DEBUG: Loaded from .env:")
-print("TWITTER_AGENT1_API_KEY:", os.getenv("TWITTER_AGENT1_API_KEY"))
-print("TWITTER_AGENT1_API_SECRET:", os.getenv("TWITTER_AGENT1_API_SECRET"))
-print("TWITTER_AGENT1_ACCESS_TOKEN:", os.getenv("TWITTER_AGENT1_ACCESS_TOKEN"))
-print("TWITTER_AGENT1_ACCESS_SECRET:", os.getenv("TWITTER_AGENT1_ACCESS_SECRET"))
 
 with open("config/logging.yaml") as f:
     logging.config.dictConfig(yaml.safe_load(f))
 
 log = logging.getLogger("runner")
+log.debug("Environment loaded")
 
 REPLY_DELAY_MIN = int(os.getenv("REPLY_DELAY_MIN", "5"))
 REPLY_DELAY_MAX = int(os.getenv("REPLY_DELAY_MAX", "20"))


### PR DESCRIPTION
## Summary
- stop printing Twitter credentials
- log when environment variables are loaded

## Testing
- `bun test` *(fails: Cannot find module '@elizaos/core')*

------
https://chatgpt.com/codex/tasks/task_e_684f9d3019a08324bfa97a77709a7939