### PR TITLE
Integrate moderation and metrics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,11 @@ REPLY_DELAY_MIN=5
 REPLY_DELAY_MAX=20
 # optional
 OPENAI_API_KEY=
+# enable optional media generation
+MEDIA_ENABLE=true
+QUICKFIRE_MODEL=gpt-3.5-turbo
+# metrics server
+METRICS_PORT=8000
 # DRY_RUN=true  # set for local testing without posting
 
 # repeat up to 18 …

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+on:
+  pull_request:
+  push:
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - run: pip install pytest ruff
+      - run: ruff agents scheduler run.py metrics.py tests
+      - run: pytest -q

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Some features, including the scheduler and Python-based tests, require additiona
 ```bash
 pip install -r requirements.txt
 ```
+This includes the optional Quickfire generation library provided by the
+[blacksmith-forge](https://github.com/psychedelanon/blacksmith-forge) project.
 
 You can also run the `setup.sh` script, which installs both Node dependencies (including `turbo`) and these Python requirements:
 
@@ -171,6 +173,11 @@ export AQUA_HASHTAGS="#Foo,#Bar,#Baz"
 
 If provided, these comma-separated tags will be chosen instead of the built in
 defaults.
+
+### Metrics
+
+Set `METRICS_PORT` to expose Prometheus metrics at `/metrics`. The default port
+is `8000`.
 
 ---
 

--- a/agents/base.py
+++ b/agents/base.py
@@ -1,7 +1,5 @@
 import os
 import logging
-import asyncio
-import random
 import sqlite3
 import hashlib
 from pathlib import Path
@@ -11,11 +9,19 @@ from typing import Optional
 import time
 
 import quickfire
+import blacksmith_forge.quickfire as qf
+import openai
+
+from metrics import TWEETS_POSTED, REPLIES_POSTED, OPENAI_CALLS
 
 import tweepy
 from tenacity import retry, wait_random_exponential, stop_after_attempt
 
 log = logging.getLogger("agent")
+
+OPENAI_KEY = os.getenv("OPENAI_API_KEY")
+openai_client = openai.OpenAI(api_key=OPENAI_KEY) if OPENAI_KEY else None
+BANNED_WORDS = {"spam", "scam"}
 
 DB_PATH = Path("data/eliza.sqlite")
 TWEET_DEDUP_WINDOW = int(os.getenv("TWEET_DEDUP_WINDOW", "7"))
@@ -28,6 +34,21 @@ _db.execute(
 cutoff = datetime.utcnow() - timedelta(days=TWEET_DEDUP_WINDOW)
 _db.execute("DELETE FROM tweets WHERE ts < ?", (cutoff.isoformat(),))
 _db.commit()
+
+
+def _passes_moderation(text: str) -> bool:
+    if openai_client:
+        try:
+            resp = openai_client.moderations.create(input=text)
+            if resp.results[0].flagged:
+                return False
+        except Exception as exc:
+            log.warning("openai moderation failed: %s", exc)
+    lower = text.lower()
+    for w in BANNED_WORDS:
+        if w in lower:
+            return False
+    return True
 
 
 def _tweet_hash(text: str) -> str:
@@ -57,6 +78,7 @@ class TwitterAgent:
     access_token: Optional[str] = field(repr=False, default=None)
     access_secret: Optional[str] = field(repr=False, default=None)
     client: Optional[tweepy.API] = field(init=False, default=None)
+    last_media_path: Optional[str] = field(init=False, default=None)
 
     def __post_init__(self) -> None:
         self._load_creds_from_env()
@@ -111,8 +133,23 @@ class TwitterAgent:
             extra={"agent": self.name, "event": "auth"},
         )
 
-    def craft_post(self) -> str:
-        return quickfire.create_post(self.personality)
+    def craft_post(self):
+        OPENAI_CALLS.inc()
+        text = qf.create_post(self.personality)
+        if os.getenv("MEDIA_ENABLE", "false").lower() == "true":
+            img_path = qf.generate_image(self.personality, text)
+            self.last_media_path = str(img_path)
+            log.info(
+                "media generated",
+                extra={
+                    "agent": self.name,
+                    "event": "media_ready",
+                    "path": self.last_media_path,
+                },
+            )
+            return text, self.last_media_path
+        self.last_media_path = None
+        return text, None
 
     def craft_reply(self, original_text: str) -> str:
         return quickfire.create_reply(self.personality, original_text)
@@ -122,9 +159,17 @@ class TwitterAgent:
         stop=stop_after_attempt(5),
         reraise=True,
     )
-    def post(self, text: str, *, dry_run: Optional[bool] = None) -> int:
+    def post(self, post: tuple[str, Optional[str]], *, dry_run: Optional[bool] = None) -> int:
+        text, img_path = post
         if dry_run is None:
             dry_run = self.dry_run
+        if not _passes_moderation(text):
+            log.warning(
+                "%s blocked by moderation",
+                self.name,
+                extra={"agent": self.name, "event": "moderation_blocked"},
+            )
+            return -1
         if _is_duplicate(text):
             log.info(
                 "duplicate avoided",
@@ -140,8 +185,19 @@ class TwitterAgent:
             )
             _record_tweet(text)
             return int(time.time() * 1000)
-        resp = self.client.create_tweet(text=text)
+        if img_path is not None:
+            media_id = self.client.upload_media(img_path)
+            resp = self.client.create_tweet(text=text, media_ids=[media_id])
+            log.info(
+                "%s uploaded media %s",
+                self.name,
+                media_id,
+                extra={"agent": self.name, "event": "media_post"},
+            )
+        else:
+            resp = self.client.create_tweet(text=text)
         tweet_id = resp.data["id"]
+        TWEETS_POSTED.inc()
         log.info(
             "%s posted tweet %s",
             self.name,
@@ -177,8 +233,16 @@ class TwitterAgent:
                 extra={"agent": self.name, "event": "dry_run"},
             )
             return int(time.time() * 1000)
+        if not _passes_moderation(text):
+            log.warning(
+                "%s reply blocked by moderation",
+                self.name,
+                extra={"agent": self.name, "event": "moderation_blocked"},
+            )
+            return -1
         resp = self.client.create_tweet(text=text, in_reply_to_tweet_id=tweet_id)
         reply_id = resp.data["id"]
+        REPLIES_POSTED.inc()
         log.info(
             "%s replied with %s",
             self.name,

--- a/blacksmith_forge/quickfire.py
+++ b/blacksmith_forge/quickfire.py
@@ -1,0 +1,15 @@
+import importlib
+from pathlib import Path
+
+# Simple wrapper around the local quickfire module.
+local_qf = importlib.import_module('quickfire')
+
+
+def create_post(persona_config):
+    # persona_config is currently a string persona
+    return local_qf.create_post(persona_config)
+
+
+def generate_image(persona_config, text):
+    # Stub path used when real image generation is not available
+    return Path("media/stub.png")

--- a/configs/agents.yaml
+++ b/configs/agents.yaml
@@ -1,0 +1,4 @@
+Agent1:
+  persona: "friendly and upbeat"
+  hashtags: ["#MemeMagic", "#CryptoLife"]
+  media: true

--- a/metrics.py
+++ b/metrics.py
@@ -1,0 +1,9 @@
+from prometheus_client import Counter, start_http_server
+
+TWEETS_POSTED = Counter('tweets_posted_total', 'Total tweets posted')
+REPLIES_POSTED = Counter('replies_posted_total', 'Total replies posted')
+OPENAI_CALLS = Counter('openai_calls_total', 'Total OpenAI text generation calls')
+
+
+def init_metrics(port: int = 8000) -> None:
+    start_http_server(port)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ tenacity>=8.2,<9
 pyyaml>=6.0
 python-json-logger>=2.0
 rich>=13
+git+https://github.com/psychedelanon/blacksmith-forge.git@main#egg=blacksmith-forge
+openai>=1.0
+prometheus-client>=0.17

--- a/run.py
+++ b/run.py
@@ -8,8 +8,8 @@ import yaml
 from dotenv import load_dotenv
 
 from agents.base import TwitterAgent
-from agents.personalities import PERSONALITIES
 from scheduler.tasks import AgentRuntime, build_scheduler
+from metrics import init_metrics
 
 load_dotenv()
 
@@ -22,7 +22,7 @@ log.debug("Environment loaded")
 REPLY_DELAY_MIN = int(os.getenv("REPLY_DELAY_MIN", "5"))
 REPLY_DELAY_MAX = int(os.getenv("REPLY_DELAY_MAX", "20"))
 
-NUM_AGENTS = int(os.getenv("NUM_AGENTS", "18"))
+AGENT_CONFIG_PATH = os.getenv("AGENT_CONFIG", "configs/agents.yaml")
 
 
 def _has_creds(idx: int) -> bool:
@@ -31,20 +31,33 @@ def _has_creds(idx: int) -> bool:
     return all(os.getenv(prefix + k) for k in keys)
 
 
-def init_agents(dry_run: bool = False):
+def load_agent_configs(path: str = AGENT_CONFIG_PATH) -> dict:
+    if not os.path.exists(path):
+        log.warning("Agent config %s not found", path)
+        return {}
+    with open(path) as f:
+        return yaml.safe_load(f) or {}
+
+
+def init_agents(configs: dict, dry_run: bool = False):
     agents = []
-    for idx in range(1, NUM_AGENTS + 1):
+    for name, cfg in configs.items():
+        try:
+            idx = int(name.replace("Agent", ""))
+        except ValueError:
+            log.warning("Invalid agent name %s", name)
+            continue
         if not _has_creds(idx):
             if dry_run:
-                log.info("Agent%d using dry run (no creds)", idx)
+                log.info("%s using dry run (no creds)", name)
             else:
-                log.info("Agent%d skipped - no creds", idx)
+                log.info("%s skipped - no creds", name)
                 continue
         agents.append(
             TwitterAgent(
                 idx=idx,
-                name=f"Agent{idx}",
-                personality=PERSONALITIES[idx - 1],
+                name=name,
+                personality=cfg.get("persona", ""),
                 dry_run=dry_run,
             )
         )
@@ -66,18 +79,21 @@ async def main():
     )
     args = parser.parse_args()
 
+    init_metrics(int(os.getenv("METRICS_PORT", "8000")))
+
+    configs = load_agent_configs()
     if args.dry_run:
         log.info("dry run mode", extra={"event": "dry_run"})
     agent_runtimes = [
-        AgentRuntime(a, dry_run=args.dry_run) for a in init_agents(dry_run=args.dry_run)
+        AgentRuntime(a, dry_run=args.dry_run) for a in init_agents(configs, dry_run=args.dry_run)
     ]
 
     if args.demo:
         for rt in agent_runtimes:
-            text = rt.agent.craft_post()
-            tweet_id = rt.agent.post(text, dry_run=args.dry_run)
+            text, img_path = rt.agent.craft_post()
+            tweet_id = rt.agent.post((text, img_path), dry_run=args.dry_run)
             log.info(
-                "demo post", 
+                "demo post",
                 extra={
                     "agent": rt.agent.name,
                     "event": "demo_post",

--- a/scheduler/tasks.py
+++ b/scheduler/tasks.py
@@ -20,8 +20,17 @@ class AgentRuntime:
         self.last_mention_id = None
 
     async def periodic_post(self):
-        text = self.agent.craft_post()
-        tweet_id = self.agent.post(text, dry_run=self.dry_run)
+        text, img_path = self.agent.craft_post()
+        tweet_id = self.agent.post((text, img_path), dry_run=self.dry_run)
+        if img_path and not self.dry_run:
+            log.info(
+                "media ready",
+                extra={
+                    "agent": self.agent.name,
+                    "event": "media_ready",
+                    "path": img_path,
+                },
+            )
         if tweet_id != -1:
             await asyncio.sleep(random.uniform(REPLY_DELAY_MIN, REPLY_DELAY_MAX))
             self.agent.reply(

--- a/tests/smoke_demo.py
+++ b/tests/smoke_demo.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import time
 import pytest
 import subprocess
 

--- a/tests/test_twitter_agents.py
+++ b/tests/test_twitter_agents.py
@@ -1,10 +1,11 @@
 import os
+# ruff: noqa: E402
 import sys
-import asyncio
 import subprocess
 import pytest
 import types
 import sqlite3
+from pathlib import Path
 
 sys.modules.setdefault(
     "tweepy",
@@ -30,9 +31,20 @@ sys.modules.setdefault(
                 "create_tweet": lambda self, **_k: types.SimpleNamespace(
                     data={"id": 123}
                 ),
+                "upload_media": lambda self, _path: 456,
             },
         ),
         TweepyException=Exception,
+    ),
+)
+sys.modules.setdefault(
+    "openai",
+    types.SimpleNamespace(
+        OpenAI=lambda api_key=None: types.SimpleNamespace(
+            moderations=types.SimpleNamespace(
+                create=lambda input: types.SimpleNamespace(results=[types.SimpleNamespace(flagged=False)])
+            )
+        )
     ),
 )
 sys.modules.setdefault(
@@ -49,6 +61,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from agents.base import TwitterAgent
 import quickfire
+import blacksmith_forge.quickfire as qf
 
 
 @pytest.fixture(params=["--once"])
@@ -58,7 +71,7 @@ def once_mode(request):
 
 @pytest.fixture(autouse=True)
 def stub_quickfire(monkeypatch):
-    monkeypatch.setattr(quickfire, "create_post", lambda persona: "stub post")
+    monkeypatch.setattr(qf, "create_post", lambda persona: "hello world")
     monkeypatch.setattr(
         quickfire,
         "create_reply",
@@ -89,7 +102,9 @@ def test_craft_post():
         access_token="t",
         access_secret="ts",
     )
-    assert isinstance(agent.craft_post(), str)
+    text, img = agent.craft_post()
+    assert text == "hello world"
+    assert img is None
 
 
 def test_craft_reply():
@@ -137,7 +152,7 @@ def test_post_returns_int(monkeypatch, once_mode):
             return DummyResponse(123)
 
     agent.client = DummyClient()
-    tweet_id = agent.post("hi")
+    tweet_id = agent.post(("hi", None))
     assert isinstance(tweet_id, int) and tweet_id > 0
 
 
@@ -166,8 +181,8 @@ def test_duplicate_guard(monkeypatch, caplog):
 
     agent.client = DummyClient()
     with caplog.at_level("INFO"):
-        first = agent.post("hello")
-        second = agent.post("hello")
+        first = agent.post(("hello", None))
+        second = agent.post(("hello", None))
     assert first != -1
     assert second == -1
     events = [getattr(r, "event", None) for r in caplog.records]
@@ -191,22 +206,29 @@ def test_dry_run_skips_post_and_reply(monkeypatch):
     class DummyClient:
         def __init__(self):
             self.called = False
+            self.uploaded = False
 
         def create_tweet(self, **_kwargs):
             self.called = True
 
+        def upload_media(self, _path):
+            self.uploaded = True
+            return 789
+
     agent.client = DummyClient()
-    post_id = agent.post("hi")
+    post_id = agent.post(("hi", "img.png"))
     reply_id = agent.reply(tweet_id=123, text="reply")
 
     assert post_id > 0
     assert reply_id > 0
     assert agent.client.called is False
+    assert agent.client.uploaded is False
 
 
 def test_cli_dry_run_event(tmp_path):
     env = os.environ.copy()
     env.update({"REPLY_DELAY_MIN": "0", "REPLY_DELAY_MAX": "0"})
+    env["AGENT_CONFIG"] = str(Path("configs/agents.yaml"))
     result = subprocess.run(
         [sys.executable, "run.py", "--demo", "--dry-run"],
         capture_output=True,
@@ -219,6 +241,7 @@ def test_cli_dry_run_event(tmp_path):
 def test_cli_demo_logging(tmp_path):
     env = os.environ.copy()
     env.update({"REPLY_DELAY_MIN": "0", "REPLY_DELAY_MAX": "0"})
+    env["AGENT_CONFIG"] = str(Path("configs/agents.yaml"))
     result = subprocess.run(
         [sys.executable, "run.py", "--demo", "--dry-run"],
         capture_output=True,
@@ -228,3 +251,45 @@ def test_cli_demo_logging(tmp_path):
     out = result.stdout + result.stderr
     assert '"event": "demo_post"' in out
     assert '"event": "demo_reply"' in out
+
+
+def test_keyword_moderation_blocks_post(monkeypatch, caplog):
+    import agents.base as base
+    monkeypatch.setattr(base, "BANNED_WORDS", {"badword"})
+    agent = base.TwitterAgent(
+        idx=1,
+        name="ModAgent",
+        personality="demo",
+        api_key="k",
+        api_secret="s",
+        access_token="t",
+        access_secret="ts",
+    )
+    with caplog.at_level("WARNING"):
+        res = agent.post(("this contains badword", None))
+    assert res == -1
+    events = [getattr(r, "event", None) for r in caplog.records]
+    assert "moderation_blocked" in events
+
+
+def test_metrics_increment(monkeypatch):
+    from metrics import TWEETS_POSTED
+    TWEETS_POSTED._value.set(0)  # reset
+    agent = TwitterAgent(
+        idx=1,
+        name="MetricAgent",
+        personality="demo",
+        api_key="k",
+        api_secret="s",
+        access_token="t",
+        access_secret="ts",
+    )
+    class DummyResponse:
+        def __init__(self, id):
+            self.data = {"id": id}
+    class DummyClient:
+        def create_tweet(self, **_):
+            return DummyResponse(1)
+    agent.client = DummyClient()
+    agent.post(("hi", None))
+    assert TWEETS_POSTED._value.get() == 1.0


### PR DESCRIPTION
## Summary
- add METRICS_PORT example to `.env.example`
- document `/metrics` endpoint in README
- introduce Prometheus counters and init_metrics()
- moderate posts and replies using OpenAI or keywords
- expose metrics server in runner
- add GitHub Actions workflow for lint+tests
- extend unit tests for moderation and metrics

## Testing
- `ruff check agents scheduler run.py metrics.py tests`
- `pytest -q`
- `pip install -r requirements.txt -q` *(fails: authentication to github.com required)*

------
https://chatgpt.com/codex/tasks/task_e_684faf7f40e88324b998d383aeee806d