### PR TITLE
Improve post skip logging and demo text

### DIFF
--- a/agents/base.py
+++ b/agents/base.py
@@ -163,17 +163,34 @@ class TwitterAgent:
         text, img_path = post
         if dry_run is None:
             dry_run = self.dry_run
+        reason = None
         if not _passes_moderation(text):
+            reason = "moderation"
             log.warning(
                 "%s blocked by moderation",
                 self.name,
                 extra={"agent": self.name, "event": "moderation_blocked"},
             )
+            log.debug(
+                "%s skip reason=%s text=%r",
+                self.name,
+                reason,
+                text,
+                extra={"agent": self.name, "event": "skip", "reason": reason},
+            )
             return -1
         if _is_duplicate(text):
+            reason = "duplicate"
             log.info(
                 "duplicate avoided",
                 extra={"agent": self.name, "event": "duplicate"},
+            )
+            log.debug(
+                "%s skip reason=%s text=%r",
+                self.name,
+                reason,
+                text,
+                extra={"agent": self.name, "event": "skip", "reason": reason},
             )
             return -1
         if dry_run:
@@ -181,7 +198,7 @@ class TwitterAgent:
                 "%s would post: %s",
                 self.name,
                 text,
-                extra={"agent": self.name, "event": "dry_run"},
+                extra={"agent": self.name, "event": "posted", "dry": True},
             )
             _record_tweet(text)
             return int(time.time() * 1000)
@@ -202,7 +219,7 @@ class TwitterAgent:
             "%s posted tweet %s",
             self.name,
             tweet_id,
-            extra={"agent": self.name, "event": "post"},
+            extra={"agent": self.name, "event": "posted", "dry": False},
         )
         _record_tweet(text)
         return tweet_id

--- a/blacksmith_forge/quickfire.py
+++ b/blacksmith_forge/quickfire.py
@@ -1,17 +1,20 @@
 import importlib
 from pathlib import Path
 import random, tempfile
+import time
 
 # Simple wrapper around the local quickfire module.
 local_qf = importlib.import_module('quickfire')
 
 
 def create_post(persona: str) -> str:
-    return f"Hello world – {persona}"
+    suffix = f" [{int(time.time()*1000)%1_000_000}]"
+    return f"Hello world{suffix} – {persona}"
 
 
 def create_reply(persona: str, original: str) -> str:
-    return f"Re {original[:40]} – {persona}"
+    suffix = f" [{int(time.time()*1000)%1_000_000}]"
+    return f"Re {original[:40]}{suffix} – {persona}"
 
 
 def generate_image(persona_config, text):

--- a/tests/smoke_demo.py
+++ b/tests/smoke_demo.py
@@ -20,6 +20,16 @@ def test_demo_smoke(monkeypatch, tmp_path, caplog):
     env["TWEET_DEDUP_WINDOW"] = "1"
     env.pop("OPENAI_API_KEY", None)  # Unset OpenAI key to test fallback
 
+    # Stub quickfire to return deterministic text
+    stub_dir = tmp_path / "stubs" / "blacksmith_forge"
+    stub_dir.mkdir(parents=True)
+    (stub_dir / "__init__.py").write_text("")
+    (stub_dir / "quickfire.py").write_text(
+        "def create_post(p):\n    return 'demo'\n"
+        "def create_reply(p,o):\n    return 'demo'\n"
+    )
+    env["PYTHONPATH"] = f"{stub_dir.parent}:{env.get('PYTHONPATH','')}"
+
     # Patch asyncio.sleep to record delays
     sleep_calls = []
     def fake_sleep(secs):

--- a/tests/test_price_bot.py
+++ b/tests/test_price_bot.py
@@ -1,5 +1,9 @@
 import asyncio
+import os
+import sys
 from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import scheduler.tasks as tasks
 
@@ -21,6 +25,7 @@ class DummyRuntime:
 def test_daily_price_post(monkeypatch):
     monkeypatch.setattr(tasks.prices, "get_prices", lambda: (30000, 0.00123))
     monkeypatch.setattr(tasks.qf, "generate_price_chart", lambda b, h: Path("stub.png"))
+    monkeypatch.setenv("MEDIA_ENABLE", "true")
 
     rt = DummyRuntime()
     asyncio.run(tasks.daily_price_post(rt))

--- a/tests/test_twitter_agents.py
+++ b/tests/test_twitter_agents.py
@@ -189,7 +189,7 @@ def test_duplicate_guard(monkeypatch, caplog):
     assert first != -1
     assert second == -1
     events = [getattr(r, "event", None) for r in caplog.records]
-    post_count = events.count("post")
+    post_count = events.count("posted")
     dup_count = events.count("duplicate")
     if post_count != 1 or dup_count != 1:
         for r in caplog.records:


### PR DESCRIPTION
## Summary
- add skip reason debug logs in TwitterAgent.post
- ensure demo quickfire text always unique with timestamp
- update tests for new event and deterministic demo

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685090d8f8308324a982fb2bc5e4c007