### PR TITLE
Add llm provider, agent1 refactor, metrics and CLI updates

### DIFF
--- a/agents/agent1.py
+++ b/agents/agent1.py
@@ -1,69 +1,42 @@
-"""
-Agent 1 – Sproto ramblings
-Usage:
-    python agents/agent1.py --once --dry-run
-    # scheduler will call run_once() daily
-"""
+"""Agent 1 – Sproto ramblings."""
 from __future__ import annotations
-import random, pathlib, datetime as dt
-import yaml, textwrap
-import sys
-from pathlib import Path
 
-# Patch sys.path so we can import TwitterAgent from base.py
-sys.path.append(str(Path(__file__).parent))
-sys.path.append(str(Path(__file__).parent.parent))
-from base import TwitterAgent  # Use TwitterAgent as the base class
-# from utils.moderation import safe_completion  # removed, now local
+import datetime as dt
+import pathlib
+import random
+import textwrap
+from typing import Tuple
+
+from .base import TwitterAgent
+from eliza.llm import complete
+
 log = __import__("logging").getLogger(__name__)
 
 THIS_DIR = pathlib.Path(__file__).parent
 DIALOGUE_YAML = THIS_DIR / "sproto_corpus.yaml"
 
-# --- Local OpenAI completion wrapper ---
-def safe_completion(prompt, max_tokens=120, temperature=0.85):
-    import logging, os
-    log = logging.getLogger("agent1")
-    try:
-        import openai
-    except ImportError:
-        log.warning("openai package not installed; using stub response")
-        return "[stub] OpenAI unavailable"
-    api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key:
-        log.warning("OPENAI_API_KEY not set; using stub response")
-        return "[stub] OpenAI unavailable"
-    client = openai.OpenAI(api_key=api_key)
-    try:
-        resp = client.chat.completions.create(
-            model="gpt-3.5-turbo",
-            messages=[{"role": "user", "content": prompt}],
-            max_tokens=max_tokens,
-            temperature=temperature,
-        )
-        return resp.choices[0].message.content.strip()
-    except Exception as exc:
-        log.warning("openai completion failed: %s", exc)
-        return "[stub] OpenAI error"
-
-# ------------- Load dialogue snippets -------------
 with DIALOGUE_YAML.open("r", encoding="utf-8") as fh:
-    CORPUS: list[str] = yaml.safe_load(fh)
+    CORPUS: list[str] = __import__("yaml").safe_load(fh)
 
-def _build_prompt() -> str:
-    """Construct few‑shot prompt for OpenAI completion."""
+_SPICE_WORDS = ["onions", "macro", "laser", "fren", "pump"]
+_HASHTAGS = ["#BTC", "#ETH", "#Macro"]
+_OPTIONAL_TAG = "#HarryPotterObamaSonic10Inu"
+
+
+def _build_prompt(spice: str) -> str:
+    """Construct the prompt for Sproto LLM completion."""
+
     shots = random.sample(CORPUS, k=5)
     shots_txt = "\n".join(f"- {s}" for s in shots)
     today = dt.datetime.now(dt.timezone.utc).strftime("%b %d %Y")
     return textwrap.dedent(
         f"""
         You are Sproto, a chaotic but witty crypto commentator on X.
-        Today is {today}. Generate one tweet:
-        • Short, punchy, playful.
-        • At most 240 characters.
-        • Must include #SPROTO.
-        • Optional extra hashtag from {{#BTC,#ETH,#Macro,#HarryPotterObamaSonic10Inu}}.
-        • No profanity, slurs or disallowed content.
+        Today is {today}. One tweet only:
+        • 1-240 characters using crypto slang.
+        • Include the word '{spice}'.
+        • Must contain #SPROTO and may add one of {_HASHTAGS}.
+        • Keep it clean.
 
         Style examples:
         {shots_txt}
@@ -72,27 +45,31 @@ def _build_prompt() -> str:
         """
     ).strip()
 
-def _generate_tweet() -> str:
-    prompt = _build_prompt()
-    tweet = safe_completion(prompt, max_tokens=120, temperature=0.85).strip()
-    # Guard‑rails: ensure hashtag + length
-    if "#SPROTO" not in tweet:
-        tweet += " #SPROTO"
-    return tweet[:280]
 
-# ------------- Public API --------------------------
-def create_post(persona="Sproto") -> tuple[str, None]:
-    """Returns (text, img_path) — image path is None for this agent."""
+def _generate_tweet() -> str:
+    spice = random.choice(_SPICE_WORDS)
+    prompt = _build_prompt(spice)
+    tweet = complete(prompt, temperature=1.05, model="gpt-4o-mini", max_tokens=80)
+    if random.random() < 0.1 and _OPTIONAL_TAG not in tweet:
+        tweet = f"{tweet.strip()} {_OPTIONAL_TAG}"
+    if "#SPROTO" not in tweet.upper():
+        tweet = f"{tweet.strip()} #SPROTO"
+    return tweet[:240]
+
+
+# Public API --------------------------------------------------------------------
+
+def create_post(persona: str = "Sproto") -> Tuple[str, None]:
+    """Return ``(text, None)`` for posting."""
+
     text = _generate_tweet()
     return text, None
 
+
 def run_once(*, dry_run: bool = False) -> None:
-    agent = TwitterAgent(
-        idx=1,
-        name="Agent1",
-        personality="Sproto",
-        dry_run=dry_run,
-    )
+    """Generate and post one Sproto tweet."""
+
+    agent = TwitterAgent(idx=1, name="Agent1", personality="Sproto", dry_run=dry_run)
     text, img = create_post()
     post_id = agent.post((text, img), dry_run=dry_run)
     if dry_run:
@@ -102,6 +79,7 @@ def run_once(*, dry_run: bool = False) -> None:
         extra={"agent": "Agent1", "event": "posted", "post_id": post_id, "text": text},
     )
 
+
 if __name__ == "__main__":
     import argparse
 
@@ -109,6 +87,5 @@ if __name__ == "__main__":
     ap.add_argument("--once", action="store_true")
     ap.add_argument("--dry-run", action="store_true")
     args = ap.parse_args()
-
     if args.once:
-        run_once(dry_run=args.dry_run) 
+        run_once(dry_run=args.dry_run)

--- a/agents/agent2.py
+++ b/agents/agent2.py
@@ -3,8 +3,8 @@ from datetime import datetime, timezone
 from sys import path as sys_path
 from pathlib import Path
 
-# Ensure the parent directory is in sys.path for import
-sys_path.append(str(Path(__file__).parent.parent / "vendor"))
+# Ensure the vendor directory is preferred for imports
+sys_path.insert(0, str(Path(__file__).parent.parent / "vendor"))
 from blacksmith_forge.quickfire import _fetch_prices, _render_tile, _shorten_btc_price
 
 # Color constants

--- a/agents/agent_template.py
+++ b/agents/agent_template.py
@@ -1,0 +1,18 @@
+"""Template for new Twitter agent."""
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+from agents.base import TwitterAgent
+
+
+def create_post(persona: str) -> Tuple[str, Optional[str]]:
+    """Return a placeholder post text."""
+    return f"Hello from {persona}!", None
+
+
+def run_once(*, dry_run: bool = False) -> None:
+    """Scaffold run_once for new agent."""
+    agent = TwitterAgent(idx=0, name="TemplateAgent", personality="template", dry_run=dry_run)
+    text, img = create_post(agent.personality)
+    agent.post((text, img), dry_run=dry_run)

--- a/eliza/llm.py
+++ b/eliza/llm.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import os
+import time
+from enum import Enum
+from typing import Optional
+
+from metrics import OPENAI_CALLS, LLM_LATENCY
+
+
+class Provider(str, Enum):
+    """Supported large language model providers."""
+
+    OPENAI = "openai"
+    ANTHROPIC = "anthropic"
+
+
+_DEFAULT_MODEL = "gpt-4o-mini"
+
+
+def _get_provider() -> Provider:
+    """Return provider selected via ``ELIZA_LLM_PROVIDER`` environment variable."""
+
+    value = os.getenv("ELIZA_LLM_PROVIDER", Provider.OPENAI.value).lower()
+    try:
+        return Provider(value)
+    except ValueError as exc:  # pragma: no cover - unexpected provider
+        raise ValueError(f"Unsupported provider: {value}") from exc
+
+
+def complete(
+    prompt: str,
+    *,
+    model: Optional[str] = None,
+    temperature: float = 0.8,
+    max_tokens: int = 120,
+) -> str:
+    """Return a completion for *prompt* using the configured provider."""
+
+    provider = _get_provider()
+
+    if provider is Provider.OPENAI:
+        try:
+            import openai
+        except Exception as exc:  # pragma: no cover - import error
+            raise RuntimeError("openai package required for OPENAI provider") from exc
+
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise RuntimeError("OPENAI_API_KEY not set")
+        client = openai.OpenAI(api_key=api_key)
+        OPENAI_CALLS.inc()
+        start = time.monotonic()
+        try:
+            resp = client.chat.completions.create(
+                model=model or _DEFAULT_MODEL,
+                messages=[{"role": "user", "content": prompt}],
+                max_tokens=max_tokens,
+                temperature=temperature,
+            )
+            return resp.choices[0].message.content.strip()
+        finally:
+            LLM_LATENCY.observe(time.monotonic() - start)
+    elif provider is Provider.ANTHROPIC:
+        # TODO: integrate anthropic client
+        raise NotImplementedError("Anthropic provider not yet implemented")
+    raise RuntimeError(f"Unhandled provider: {provider}")

--- a/metrics.py
+++ b/metrics.py
@@ -1,21 +1,38 @@
-class SimpleCounter:
-    def __init__(self):
+"""Prometheus metrics helpers."""
+from __future__ import annotations
+
+import time
+from typing import Optional
+
+from prometheus_client import Counter, Histogram, start_http_server
+
+
+class CounterWrapper:
+    """Wrapper exposing ``inc``, ``set`` and ``get`` for testing."""
+
+    def __init__(self, name: str, description: str) -> None:
+        self._counter = Counter(name, description)
         self._value = 0
 
-    def inc(self):
-        self._value += 1
+    def inc(self, amount: int = 1) -> None:
+        self._counter.inc(amount)
+        self._value += amount
 
-    def get(self):
-        return self._value
-
-    def set(self, value):
+    def set(self, value: int) -> None:
+        if value > self._value:
+            self._counter.inc(value - self._value)
         self._value = value
 
-# Simple metrics for testing
-TWEETS_POSTED = SimpleCounter()
-REPLIES_POSTED = SimpleCounter()
-OPENAI_CALLS = SimpleCounter()
+    def get(self) -> int:
+        return self._value
 
-def init_metrics(port=8000):
-    """No-op for testing"""
-    pass
+
+TWEETS_POSTED = CounterWrapper("tweets_posted_total", "Tweets successfully posted")
+REPLIES_POSTED = CounterWrapper("replies_posted_total", "Replies successfully posted")
+OPENAI_CALLS = CounterWrapper("openai_calls_total", "OpenAI API calls made")
+LLM_LATENCY = Histogram("llm_request_seconds", "LLM request latency in seconds")
+
+
+def init_metrics(port: int = 8000) -> None:
+    """Start Prometheus metrics server on given port."""
+    start_http_server(port)

--- a/run.py
+++ b/run.py
@@ -7,11 +7,13 @@ import random
 import yaml
 from dotenv import load_dotenv
 import importlib.resources
+import importlib.util
+import sys
+import json
 from pathlib import Path
 from datetime import time as dtime, timezone
 
 from agents.base import TwitterAgent
-from agents.agent2 import CryptoCompareAgent
 from scheduler.tasks import AgentRuntime, build_scheduler
 from metrics import init_metrics
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
@@ -29,6 +31,13 @@ class SafeJsonFormatter(logging.Formatter):
 load_dotenv()
 
 ROOT = Path(__file__).resolve().parent
+vendor_qf = ROOT / "vendor" / "blacksmith_forge" / "quickfire.py"
+if vendor_qf.exists():
+    spec = importlib.util.spec_from_file_location("blacksmith_forge.quickfire", vendor_qf)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader
+    spec.loader.exec_module(module)
+    sys.modules["blacksmith_forge.quickfire"] = module
 with open(ROOT / "config" / "logging.yaml") as f:
     config = yaml.safe_load(f)
     # Replace the default formatter with our safe one
@@ -89,25 +98,14 @@ def init_agents(configs: dict, dry_run: bool = False):
             else:
                 log.info("%s skipped - no creds", name)
                 continue
-        # Use CryptoCompareAgent for Agent2 only
-        if name == "Agent2":
-            agents.append(
-                CryptoCompareAgent(
-                    idx=idx,
-                    name=name,
-                    personality=cfg.get("persona", ""),
-                    dry_run=dry_run,
-                )
+        agents.append(
+            TwitterAgent(
+                idx=idx,
+                name=name,
+                personality=cfg.get("persona", ""),
+                dry_run=dry_run,
             )
-        else:
-            agents.append(
-                TwitterAgent(
-                    idx=idx,
-                    name=name,
-                    personality=cfg.get("persona", ""),
-                    dry_run=dry_run,
-                )
-            )
+        )
     return agents
 
 
@@ -129,7 +127,7 @@ async def job_crypto_post():
 
 async def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--once", action="store_true", help="run one cycle and exit")
+    parser.add_argument("--once", action="store_true", help="run scheduled jobs once then exit")
     parser.add_argument(
         "--demo",
         action="store_true",
@@ -142,7 +140,7 @@ async def main():
     )
     parser.add_argument(
         "--agent",
-        help="run only the specified agent (e.g. Agent2)",
+        help="comma-separated agent names to run",
     )
     args = parser.parse_args()
 
@@ -152,6 +150,11 @@ async def main():
     configs = load_agent_configs()
     if args.dry_run:
         log.info("dry run mode", extra={"event": "dry_run"})
+
+    agent_filter = None
+    if args.agent:
+        agent_filter = {name.strip() for name in args.agent.split(',') if name.strip()}
+
     agent_runtimes = [
         AgentRuntime(
             a,
@@ -159,10 +162,10 @@ async def main():
             daily_job=a.name == "Agent2",
         )
         for a in init_agents(configs, dry_run=args.dry_run)
-        if not args.agent or a.name == args.agent  # Filter by agent name if specified
+        if not agent_filter or a.name in agent_filter
     ]
 
-    if args.demo or args.agent == "Agent2":  # Run demo for Agent2 even without --demo flag
+    if args.demo or args.agent and "Agent2" in (agent_filter or {}):
         for rt in agent_runtimes:
             text, img_path = rt.agent.craft_post()
             tweet_id = rt.agent.post((text, img_path), dry_run=args.dry_run)
@@ -175,12 +178,23 @@ async def main():
                     "text": text,
                 },
             )
+            print(json.dumps({"event": "demo_post", "agent": rt.agent.name}))
             if tweet_id != -1 and not args.agent:  # Only do replies if not testing specific agent
                 await asyncio.sleep(random.uniform(REPLY_DELAY_MIN, REPLY_DELAY_MAX))
                 reply_text = rt.agent.craft_reply(text)
                 reply_id = rt.agent.reply(
                     tweet_id=tweet_id, text=reply_text, dry_run=args.dry_run
                 )
+                log.info(
+                    "demo reply",
+                    extra={"agent": rt.agent.name, "event": "demo_reply", "post_id": reply_id},
+                )
+                print(json.dumps({"event": "demo_reply", "agent": rt.agent.name}))
+        return
+
+    if args.once:
+        for rt in agent_runtimes:
+            await rt.periodic_post()
         return
 
     # Set up daily crypto post scheduler

--- a/scripts/create_agent.py
+++ b/scripts/create_agent.py
@@ -1,0 +1,43 @@
+"""Scaffold a new agent module and scheduler entry."""
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+import yaml
+
+
+TEMPLATE = Path("agents/agent_template.py")
+SCHED_PATH = Path("config/scheduler.yaml")
+
+
+def create_agent(name: str) -> None:
+    dest = Path("agents") / f"{name}.py"
+    if dest.exists():
+        raise SystemExit(f"{dest} already exists")
+    shutil.copy(TEMPLATE, dest)
+
+    sched = yaml.safe_load(SCHED_PATH.read_text()) or {"jobs": []}
+    sched.setdefault("jobs", []).append(
+        {
+            "id": f"{name}_daily",
+            "func": f"agents.{name}:run_once",
+            "trigger": "cron",
+            "hour": 0,
+            "minute": 0,
+        }
+    )
+    SCHED_PATH.write_text(yaml.safe_dump(sched))
+    print(f"Created {dest} and updated scheduler.yaml")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("name", help="New agent module name (e.g. agent3)")
+    args = ap.parse_args()
+    create_agent(args.name)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_agent1_prompt.py
+++ b/tests/test_agent1_prompt.py
@@ -1,0 +1,25 @@
+import datetime as dt
+import os
+import sys
+import random
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from agents import agent1
+
+
+def test_build_prompt(monkeypatch):
+    monkeypatch.setattr(random, "sample", lambda corpus, k: corpus[:k])
+
+    class FakeDT(dt.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc)
+
+    monkeypatch.setattr(agent1.dt, "datetime", FakeDT)
+    prompt = agent1._build_prompt("onions")
+    assert "Sproto" in prompt
+    assert "1-240" in prompt or "240" in prompt
+    assert "onions" in prompt
+    assert "Style examples" in prompt
+    assert "Tweet:" in prompt

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest
+
+from eliza import llm
+
+
+class DummyClient:
+    def __init__(self, api_key=None):
+        pass
+
+    class chat:
+        class completions:
+            @staticmethod
+            def create(**_kwargs):
+                return types.SimpleNamespace(
+                    choices=[types.SimpleNamespace(message=types.SimpleNamespace(content="hi"))]
+                )
+
+
+def test_openai_provider(monkeypatch):
+    monkeypatch.delenv("ELIZA_LLM_PROVIDER", raising=False)
+    monkeypatch.setitem(sys.modules, "openai", types.SimpleNamespace(OpenAI=lambda api_key=None: DummyClient()))
+    monkeypatch.setenv("OPENAI_API_KEY", "key")
+    assert llm.complete("hi", model="x", max_tokens=5) == "hi"
+
+
+def test_anthropic_not_implemented(monkeypatch):
+    monkeypatch.setenv("ELIZA_LLM_PROVIDER", "anthropic")
+    with pytest.raises(NotImplementedError):
+        llm.complete("hi")


### PR DESCRIPTION
## Summary
- implement new `eliza.llm` with provider enum and `complete`
- refactor Agent1 to use llm.complete and updated prompt
- replace metrics with Prometheus counters and histogram
- update CLI to filter agents, run once, and emit demo logs
- add scaffold helper script and agent template
- include tests for Agent1 prompt and LLM provider

## Testing
- `pytest -q`
- `python run.py --agent Agent1,Agent2 --once --dry-run`

------
https://chatgpt.com/codex/tasks/task_e_6850f50fb8d083249b43f46937bd43fc