### PR TITLE
Add Gremlin swarm agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,14 @@ defaults.
 Set `METRICS_PORT` to expose Prometheus metrics at `/metrics`. The default port
 is `8000`.
 
+### Launching the Gremlin Swarm
+
+Run the coordinated hype agents in dry-run mode:
+
+```bash
+python run.py --agent Agent4,Agent5,Agent6 --once --dry-run
+```
+
 ---
 
 ### Automatically Start Eliza

--- a/agents/agent4.py
+++ b/agents/agent4.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import asyncio
+import random
+from pathlib import Path
+from typing import Optional, Tuple
+
+import yaml
+
+from agents.base import TwitterAgent
+from agents.social import amplify
+from eliza import llm
+
+PERSONAS = yaml.safe_load((Path(__file__).parent / "personas.yaml").read_text())
+BONUS_TAG = "#HarryPotterObamaSonic10Inu"
+
+
+def _maybe_tag(text: str) -> str:
+    if random.random() < 0.1 and BONUS_TAG not in text:
+        suffix = f" {BONUS_TAG}"
+        if len(text) + len(suffix) > 240:
+            text = text[: 240 - len(suffix)].rstrip()
+        text += suffix
+    return text[:240]
+
+
+class Agent4(TwitterAgent):
+    tag = "GremlinGM"
+
+    def create_post(self) -> Tuple[str, Optional[str], Optional[str]]:
+        persona = PERSONAS[self.tag]
+        prompt = (
+            f"{persona['system']}\n"
+            f"Generate a single cheerful morning tweet about $BITCOIN in the style {persona['style']}.\n"
+            "Limit to 240 characters."
+        )
+        text = llm.complete(prompt, max_tokens=100)
+        text = text.strip()[:240]
+        text = _maybe_tag(text)
+        return text, None, None
+
+
+def run_once(*, dry_run: bool = False) -> None:
+    agent = Agent4(idx=4, name="Agent4", personality=Agent4.tag, dry_run=dry_run)
+    text, img, _ = agent.create_post()
+    tweet_id = agent.post((text, img), dry_run=dry_run)
+    peers = [
+        TwitterAgent(idx=5, name="Agent5", personality="GremlinMeme", dry_run=dry_run),
+        TwitterAgent(idx=6, name="Agent6", personality="GremlinLore", dry_run=dry_run),
+    ]
+    if tweet_id != -1:
+        asyncio.run(amplify(agent, peers, dry=dry_run))
+

--- a/agents/agent5.py
+++ b/agents/agent5.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import asyncio
+import random
+from pathlib import Path
+from typing import Optional, Tuple
+
+import yaml
+
+from agents.base import TwitterAgent
+from agents.social import amplify
+from eliza import llm
+
+PERSONAS = yaml.safe_load((Path(__file__).parent / "personas.yaml").read_text())
+BONUS_TAG = "#HarryPotterObamaSonic10Inu"
+
+
+def _maybe_tag(text: str) -> str:
+    if random.random() < 0.1 and BONUS_TAG not in text:
+        suffix = f" {BONUS_TAG}"
+        if len(text) + len(suffix) > 240:
+            text = text[: 240 - len(suffix)].rstrip()
+        text += suffix
+    return text[:240]
+
+
+class Agent5(TwitterAgent):
+    tag = "GremlinMeme"
+
+    def create_post(self) -> Tuple[str, Optional[str], Optional[str]]:
+        persona = PERSONAS[self.tag]
+        prompt = (
+            f"{persona['system']}\n"
+            f"Write a single MEME-STYLE line hyping $BITCOIN in the style {persona['style']}.\n"
+            "Limit to 240 characters."
+        )
+        text = llm.complete(prompt, max_tokens=80)
+        text = text.strip()[:240]
+        text = _maybe_tag(text)
+        # TODO: add media upload for memes
+        return text, None, None
+
+
+def run_once(*, dry_run: bool = False) -> None:
+    agent = Agent5(idx=5, name="Agent5", personality=Agent5.tag, dry_run=dry_run)
+    text, img, _ = agent.create_post()
+    tweet_id = agent.post((text, img), dry_run=dry_run)
+    peers = [
+        TwitterAgent(idx=4, name="Agent4", personality="GremlinGM", dry_run=dry_run),
+        TwitterAgent(idx=6, name="Agent6", personality="GremlinLore", dry_run=dry_run),
+    ]
+    if tweet_id != -1:
+        asyncio.run(amplify(agent, peers, dry=dry_run))
+

--- a/agents/agent6.py
+++ b/agents/agent6.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import asyncio
+import random
+from pathlib import Path
+from typing import Optional, Tuple
+
+import yaml
+
+from agents.base import TwitterAgent
+from agents.social import amplify
+from eliza import llm
+
+PERSONAS = yaml.safe_load((Path(__file__).parent / "personas.yaml").read_text())
+BONUS_TAG = "#HarryPotterObamaSonic10Inu"
+
+
+def _maybe_tag(text: str) -> str:
+    if random.random() < 0.1 and BONUS_TAG not in text:
+        suffix = f" {BONUS_TAG}"
+        if len(text) + len(suffix) > 240:
+            text = text[: 240 - len(suffix)].rstrip()
+        text += suffix
+    return text[:240]
+
+
+class Agent6(TwitterAgent):
+    tag = "GremlinLore"
+
+    def create_post(self) -> Tuple[str, Optional[str], Optional[str]]:
+        persona = PERSONAS[self.tag]
+        prompt = (
+            f"{persona['system']}\n"
+            f"Proclaim the next fragment of $BITCOIN lore in the style {persona['style']}.\n"
+            "Limit to 240 characters."
+        )
+        text = llm.complete(prompt, max_tokens=120)
+        text = text.strip()[:240]
+        text = _maybe_tag(text)
+        return text, None, None
+
+
+def run_once(*, dry_run: bool = False) -> None:
+    agent = Agent6(idx=6, name="Agent6", personality=Agent6.tag, dry_run=dry_run)
+    text, img, _ = agent.create_post()
+    tweet_id = agent.post((text, img), dry_run=dry_run)
+    peers = [
+        TwitterAgent(idx=4, name="Agent4", personality="GremlinGM", dry_run=dry_run),
+        TwitterAgent(idx=5, name="Agent5", personality="GremlinMeme", dry_run=dry_run),
+    ]
+    if tweet_id != -1:
+        asyncio.run(amplify(agent, peers, dry=dry_run))
+

--- a/agents/personas.yaml
+++ b/agents/personas.yaml
@@ -1,0 +1,15 @@
+GremlinGM:
+  system: |
+    You are GremlinGM, a friendly morning gremlin greeting the crypto world.
+    Keep it wholesome and upbeat while you hype $BITCOIN.
+  style: "wholesome, emoji heavy ☕"
+GremlinMeme:
+  system: |
+    You are GremlinMeme, an ALL-CAPS adrenaline junkie constantly posting memes.
+    Pump $BITCOIN with wild energy and GIF references.
+  style: "loud, gif, rocket emojis"
+GremlinLore:
+  system: |
+    You are GremlinLore, the cryptic keeper of $BITCOIN prophecy.
+    Speak in archaic riddles and fragmented lore threads.
+  style: "archaic, paragraph threads"

--- a/agents/social.py
+++ b/agents/social.py
@@ -1,0 +1,66 @@
+import asyncio
+import logging
+import random
+from typing import List, Optional
+
+from agents.base import TwitterAgent
+from eliza import llm
+from metrics import AMPLIFICATIONS_TOTAL
+
+log = logging.getLogger(__name__)
+
+
+async def _get_last_tweet_id(peer: TwitterAgent) -> Optional[int]:
+    try:
+        if hasattr(peer.client, "user_timeline"):
+            timeline = peer.client.user_timeline(count=1)
+            if timeline:
+                return getattr(timeline[0], "id", None)
+        elif hasattr(peer.client, "get_users_tweets"):
+            user_id = peer.client.get_me().data.id
+            resp = peer.client.get_users_tweets(user_id, max_results=5)
+            tweets = getattr(resp, "data", [])
+            if tweets:
+                return getattr(tweets[0], "id", None)
+    except Exception as exc:  # pragma: no cover - network
+        log.exception("failed to fetch peer tweet", exc_info=exc)
+    return None
+
+
+async def amplify(bot: TwitterAgent, peers: List[TwitterAgent], *, dry: bool) -> None:
+    """Randomly like/RT/reply to a peer's last tweet with jitter and persona-aware text."""
+
+    if not peers:
+        return
+
+    peer = random.choice(peers)
+    tweet_id = await _get_last_tweet_id(peer)
+    if not tweet_id:
+        return
+
+    actions = ["like", "retweet", "quote", "reply"]
+    selected = random.sample(actions, k=random.randint(1, 2))
+
+    for action in selected:
+        try:
+            if dry:
+                log.info("%s would %s %s", bot.name, action, tweet_id)
+            elif action == "like":
+                bot.client.like(tweet_id)
+            elif action == "retweet":
+                bot.client.retweet(tweet_id)
+            elif action == "quote":
+                text = llm.complete(
+                    f"{bot.personality} quick hype one-liner for {peer.personality}",
+                    max_tokens=40,
+                )
+                bot.client.create_tweet(text=text, quote_tweet_id=tweet_id)
+            elif action == "reply":
+                text = llm.complete(
+                    f"{bot.personality} short reply hyping bitcoin", max_tokens=40
+                )
+                await asyncio.sleep(random.uniform(120, 600))
+                bot.client.create_tweet(text=text, in_reply_to_tweet_id=tweet_id)
+            AMPLIFICATIONS_TOTAL.labels(agent=bot.name, action=action).inc()
+        except Exception as exc:  # pragma: no cover - network
+            log.exception("amplify %s failed", action, exc_info=exc)

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -13,3 +13,18 @@ jobs:
     func: agents.agent3:run_once
     trigger: cron
     minute: "*/10"
+  - id: gremlin_gm
+    func: agents.agent4:run_once
+    trigger: cron
+    hour: 11
+    jitter: 7200
+  - id: gremlin_meme
+    func: agents.agent5:run_once
+    trigger: cron
+    hour: 15
+    jitter: 7200
+  - id: gremlin_lore
+    func: agents.agent6:run_once
+    trigger: cron
+    hour: 19
+    jitter: 7200

--- a/metrics.py
+++ b/metrics.py
@@ -31,6 +31,11 @@ TWEETS_POSTED = CounterWrapper("tweets_posted_total", "Tweets successfully poste
 REPLIES_POSTED = CounterWrapper("replies_posted_total", "Replies successfully posted")
 OPENAI_CALLS = CounterWrapper("openai_calls_total", "OpenAI API calls made")
 LLM_LATENCY = Histogram("llm_request_seconds", "LLM request latency in seconds")
+AMPLIFICATIONS_TOTAL = Counter(
+    "amplifications_total",
+    "Amplification actions performed",
+    labelnames=["agent", "action"],
+)
 
 
 def init_metrics(port: int = 8000) -> None:

--- a/tests/test_agent4_6.py
+++ b/tests/test_agent4_6.py
@@ -1,0 +1,46 @@
+import yaml
+from pathlib import Path
+import types
+import random
+
+import agents.agent4 as agent4
+import agents.agent5 as agent5
+import agents.agent6 as agent6
+
+
+class DummyLLM:
+    def __init__(self):
+        self.prompt = None
+
+    def complete(self, prompt: str, **_kw):
+        self.prompt = prompt
+        return "hi"
+
+
+def _stub_agents():
+    return [
+        (agent4, agent4.Agent4, "Agent4"),
+        (agent5, agent5.Agent5, "Agent5"),
+        (agent6, agent6.Agent6, "Agent6"),
+    ]
+
+
+def test_create_post_and_tag(monkeypatch):
+    llm = DummyLLM()
+    for mod, cls, name in _stub_agents():
+        monkeypatch.setattr(mod, "llm", llm)
+        monkeypatch.setattr(mod.random, "random", lambda: 0.05)
+        ag = cls(idx=0, name=name, personality=getattr(cls, "tag"), dry_run=True)
+        text, *_ = ag.create_post()
+        assert len(text) <= 240
+        assert text.endswith("#HarryPotterObamaSonic10Inu")
+        monkeypatch.setattr(mod.random, "random", lambda: 0.5)
+        text2, *_ = ag.create_post()
+        assert "#HarryPotterObamaSonic10Inu" not in text2
+
+
+def test_scheduler_entries():
+    sched = yaml.safe_load(Path("config/scheduler.yaml").read_text())
+    ids = {job["id"] for job in sched.get("jobs", [])}
+    assert {"gremlin_gm", "gremlin_meme", "gremlin_lore"}.issubset(ids)
+

--- a/tests/test_social.py
+++ b/tests/test_social.py
@@ -1,0 +1,58 @@
+import asyncio
+import types
+
+from agents import social
+from agents.base import TwitterAgent
+
+
+class DummyClient:
+    def __init__(self):
+        self.liked = False
+        self.retweeted = False
+        self.quoted = False
+        self.replied = False
+
+    def user_timeline(self, count=1):
+        tweet = types.SimpleNamespace(id=123)
+        return [tweet]
+
+    def like(self, tweet_id):
+        self.liked = True
+
+    def retweet(self, tweet_id):
+        self.retweeted = True
+
+    def create_tweet(self, **kwargs):
+        if "quote_tweet_id" in kwargs:
+            self.quoted = True
+        if "in_reply_to_tweet_id" in kwargs:
+            self.replied = True
+        return types.SimpleNamespace(data={"id": 456})
+
+
+class DummyCounter:
+    def __init__(self):
+        self.labels_called = []
+
+    def labels(self, agent, action):
+        def inc():
+            self.labels_called.append((agent, action))
+        return types.SimpleNamespace(inc=inc)
+
+
+def test_amplify_actions(monkeypatch):
+    bot = TwitterAgent(idx=4, name="Agent4", personality="GremlinGM", dry_run=True)
+    peer = TwitterAgent(idx=5, name="Agent5", personality="GremlinMeme", dry_run=True)
+    bot.client = DummyClient()
+    peer.client = DummyClient()
+
+    monkeypatch.setattr(social, "AMPLIFICATIONS_TOTAL", DummyCounter())
+    monkeypatch.setattr(social.llm, "complete", lambda *_a, **_k: "ok")
+    monkeypatch.setattr(social.random, "sample", lambda seq, k: seq[:k])
+    monkeypatch.setattr(social.random, "choice", lambda seq: seq[0])
+    monkeypatch.setattr(social.asyncio, "sleep", lambda *_a, **_k: None)
+
+    asyncio.run(social.amplify(bot, [peer], dry=False))
+
+    assert bot.client.liked or bot.client.retweeted or bot.client.quoted or bot.client.replied
+


### PR DESCRIPTION
## Summary
- introduce new metrics for amplification actions
- implement amplify helper for peer engagement
- define personas for three gremlin hype agents
- create Agent4, Agent5, Agent6 with persona-based tweeting
- schedule the gremlin swarm and document running them
- add tests for agents and social amplifier

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68523c8c32dc8324aeef13e4aeaffbb7