### PR TITLE
Integrate twitter engagement plugin

### DIFF
--- a/src/networkServer.test.ts
+++ b/src/networkServer.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fetch from 'node-fetch';
+import { createEngagementServer, CoordinationServices } from './networkServer';
+import http from 'http';
+
+let server: http.Server;
+let baseUrl: string;
+let requests: any[];
+
+beforeEach(async () => {
+  requests = [];
+  const services: CoordinationServices = {
+    requestEngagement: async (postId, type, urgency) => {
+      requests.push({ postId, type, urgency });
+    },
+    getNetworkStatus: async () => ({
+      activeAgents: 2,
+      totalCapacity: 200,
+      currentLoad: 20,
+      pendingEvents: 1,
+    }),
+  };
+  const app = createEngagementServer(services);
+  server = app.listen(0);
+  const { port } = server.address() as any;
+  baseUrl = `http://localhost:${port}`;
+});
+
+afterEach(async () => {
+  await new Promise((resolve) => server.close(resolve));
+});
+
+describe('engagement server', () => {
+  it('returns network status', async () => {
+    const res = await fetch(`${baseUrl}/network/status`);
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.activeAgents).toBe(2);
+  });
+
+  it('handles coordinate request', async () => {
+    const res = await fetch(`${baseUrl}/coordinate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ targetPostId: '123', engagementTypes: ['like', 'retweet'], urgency: 'high' }),
+    });
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(requests.length).toBe(2);
+    expect(requests[0]).toEqual({ postId: '123', type: 'like', urgency: 'high' });
+  });
+});

--- a/src/networkServer.ts
+++ b/src/networkServer.ts
@@ -1,0 +1,87 @@
+import express from 'express';
+import { AgentRuntime, type Character } from '@elizaos/core';
+import { twitterEngagementPlugin } from '@elizaos/plugin-twitter-engagement';
+import dotenv from 'dotenv';
+
+export interface CoordinationServices {
+  requestEngagement: (
+    postId: string,
+    type: 'like' | 'retweet' | 'reply' | 'quote',
+    urgency?: 'high' | 'medium' | 'low'
+  ) => Promise<void>;
+  getNetworkStatus: () => Promise<{
+    activeAgents: number;
+    totalCapacity: number;
+    currentLoad: number;
+    pendingEvents: number;
+  }>;
+}
+
+export function createEngagementServer(services: CoordinationServices) {
+  const app = express();
+  app.use(express.json());
+
+  app.post('/coordinate', async (req, res) => {
+    try {
+      const {
+        targetPostId,
+        engagementTypes = ['like'],
+        urgency = 'medium',
+      } = req.body || {};
+
+      if (!targetPostId) {
+        res.status(400).json({ error: 'targetPostId required' });
+        return;
+      }
+
+      for (const type of engagementTypes as Array<'like' | 'retweet' | 'reply' | 'quote'>) {
+        await services.requestEngagement(targetPostId, type, urgency);
+      }
+
+      res.json({ success: true });
+    } catch (err: any) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  app.get('/network/status', async (_req, res) => {
+    try {
+      const status = await services.getNetworkStatus();
+      res.json(status);
+    } catch (err: any) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  return app;
+}
+
+export async function startServer(port = 3000) {
+  dotenv.config();
+  const character: Character = {
+    name: 'Coordinator',
+    username: 'coordinator',
+    plugins: ['@elizaos/plugin-twitter', '@elizaos/plugin-twitter-engagement'],
+  };
+
+  const runtime = new AgentRuntime({
+    character,
+    plugins: [twitterEngagementPlugin],
+    settings: process.env,
+  });
+
+  await runtime.initialize();
+
+  const networkService = runtime.getService('network-coordination') as CoordinationServices;
+  const app = createEngagementServer(networkService);
+
+  app.listen(port, () => {
+    console.log(`Engagement server listening on ${port}`);
+  });
+
+  return { app, runtime };
+}
+
+if (require.main === module) {
+  startServer();
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import path from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add `networkServer.ts` with a small Express server
- add unit tests for the server
- configure Vitest at repo root

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a92502ce88324b3db68d7b0a002c7